### PR TITLE
add lease role for hub

### DIFF
--- a/manifests/cluster-manager/cluster-manager-registration-clusterrole.yaml
+++ b/manifests/cluster-manager/cluster-manager-registration-clusterrole.yaml
@@ -27,6 +27,10 @@ rules:
 - apiGroups: ["rbac.authorization.k8s.io"]
   resources: ["clusterroles", "roles"]
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete", "escalate", "bind"]
+# Allow hub to manage coordination.k8s.io/lease
+- apiGroups: ["coordination.k8s.io"]
+  resources: ["leases"]
+  verbs: ["get", "list", "watch", "create", "delete", "update"]
 # Allow hub to manage managedclusters
 - apiGroups: ["cluster.open-cluster-management.io"]
   resources: ["managedclusters"]

--- a/pkg/operators/clustermanager/bindata/bindata.go
+++ b/pkg/operators/clustermanager/bindata/bindata.go
@@ -549,6 +549,10 @@ rules:
 - apiGroups: ["rbac.authorization.k8s.io"]
   resources: ["clusterroles", "roles"]
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete", "escalate", "bind"]
+# Allow hub to manage coordination.k8s.io/lease
+- apiGroups: ["coordination.k8s.io"]
+  resources: ["leases"]
+  verbs: ["get", "list", "watch", "create", "delete", "update"]
 # Allow hub to manage managedclusters
 - apiGroups: ["cluster.open-cluster-management.io"]
   resources: ["managedclusters"]


### PR DESCRIPTION
I found failed e2e tests because the cluster-manager-registration-controller pod is forbidden to list lease.
So add lease role to allow hub to manage coordination.k8s.io/lease since registration has supported spoke cluster available check.