### PR TITLE
Clusterrole on hub should be able to monitor manifestworks

### DIFF
--- a/manifests/cluster-manager/cluster-manager-registration-clusterrole.yaml
+++ b/manifests/cluster-manager/cluster-manager-registration-clusterrole.yaml
@@ -38,3 +38,7 @@ rules:
 - apiGroups: ["cluster.open-cluster-management.io"]
   resources: ["managedclusters/status"]
   verbs: ["update", "patch"]
+# Allow hub to monitor manifestworks
+- apiGroups: ["work.open-cluster-management.io"]
+  resources: ["manifestworks"]
+  verbs: ["get", "list", "watch"]

--- a/pkg/operators/clustermanager/bindata/bindata.go
+++ b/pkg/operators/clustermanager/bindata/bindata.go
@@ -582,6 +582,10 @@ rules:
 - apiGroups: ["cluster.open-cluster-management.io"]
   resources: ["managedclusters/status"]
   verbs: ["update", "patch"]
+# Allow hub to monitor manifestworks
+- apiGroups: ["work.open-cluster-management.io"]
+  resources: ["manifestworks"]
+  verbs: ["get", "list", "watch"]
 `)
 
 func manifestsClusterManagerClusterManagerRegistrationClusterroleYamlBytes() ([]byte, error) {


### PR DESCRIPTION
https://github.com/open-cluster-management/backlog/issues/3234

We need to enable e2e for this  case.