### PR TITLE
refactor degraded condition logic

### DIFF
--- a/pkg/operators/klusterlet/controllers/statuscontroller/klusterlet_status_controller_test.go
+++ b/pkg/operators/klusterlet/controllers/statuscontroller/klusterlet_status_controller_test.go
@@ -167,30 +167,35 @@ func TestSync(t *testing.T) {
 	}{
 		{
 			name:       "No bootstrap secret",
-			object:     []runtime.Object{},
+			object:     []runtime.Object{newSecret(helpers.HubKubeConfigSecret, "test")},
 			klusterlet: newKlusterlet("testklusterlet", "test", ""),
 			expectedConditions: []operatorapiv1.StatusCondition{
-				testinghelper.NamedCondition(klusterletRegistrationDegraded, "BootStrapSecretMissing", metav1.ConditionTrue),
+				testinghelper.NamedCondition(klusterletRegistrationDegraded, "BootstrapSecretMissing,HubKubeConfigMissing,GetDeploymentFailed", metav1.ConditionTrue),
+				testinghelper.NamedCondition(klusterletWorKDegraded, "HubKubeConfigMissing,GetDeploymentFailed", metav1.ConditionTrue),
 			},
 		},
 		{
 			name: "Bad bootstrap secret",
 			object: []runtime.Object{
+				newSecret(helpers.HubKubeConfigSecret, "test"),
 				newSecretWithKubeConfig(helpers.BootstrapHubKubeConfigSecret, "test", []byte("badsecret")),
 			},
 			klusterlet: newKlusterlet("testklusterlet", "test", ""),
 			expectedConditions: []operatorapiv1.StatusCondition{
-				testinghelper.NamedCondition(klusterletRegistrationDegraded, "BootstrapSecretError", metav1.ConditionTrue),
+				testinghelper.NamedCondition(klusterletRegistrationDegraded, "BootstrapSecretError,HubKubeConfigMissing,GetDeploymentFailed", metav1.ConditionTrue),
+				testinghelper.NamedCondition(klusterletWorKDegraded, "HubKubeConfigMissing,GetDeploymentFailed", metav1.ConditionTrue),
 			},
 		},
 		{
 			name: "Unauthorized bootstrap secret",
 			object: []runtime.Object{
+				newSecret(helpers.HubKubeConfigSecret, "test"),
 				newSecretWithKubeConfig(helpers.BootstrapHubKubeConfigSecret, "test", newKubeConfig(apiServerHost)),
 			},
 			klusterlet: newKlusterlet("testklusterlet", "test", ""),
 			expectedConditions: []operatorapiv1.StatusCondition{
-				testinghelper.NamedCondition(klusterletRegistrationDegraded, "BootstrapSecretUnauthorized", metav1.ConditionTrue),
+				testinghelper.NamedCondition(klusterletRegistrationDegraded, "BootstrapSecretUnauthorized,HubKubeConfigMissing,GetDeploymentFailed", metav1.ConditionTrue),
+				testinghelper.NamedCondition(klusterletWorKDegraded, "HubKubeConfigMissing,GetDeploymentFailed", metav1.ConditionTrue),
 			},
 		},
 		{
@@ -201,21 +206,21 @@ func TestSync(t *testing.T) {
 			klusterlet:                    newKlusterlet("testklusterlet", "test", ""),
 			allowToOperateManagedClusters: true,
 			expectedConditions: []operatorapiv1.StatusCondition{
-				testinghelper.NamedCondition(klusterletRegistrationDegraded, "HubKubeConfigSecretMissing", metav1.ConditionTrue),
-				testinghelper.NamedCondition(klusterletWorKDegraded, "HubKubeConfigSecretMissing", metav1.ConditionTrue),
+				testinghelper.NamedCondition(klusterletRegistrationDegraded, "HubKubeConfigSecretMissing,GetDeploymentFailed", metav1.ConditionTrue),
+				testinghelper.NamedCondition(klusterletWorKDegraded, "HubKubeConfigSecretMissing,GetDeploymentFailed", metav1.ConditionTrue),
 			},
 		},
 		{
 			name: "No cluster name secret",
 			object: []runtime.Object{
 				newSecretWithKubeConfig(helpers.BootstrapHubKubeConfigSecret, "test", newKubeConfig(apiServerHost)),
-				newSecret(helpers.HubKubeConfigSecret, "test"),
+				newSecretWithKubeConfig(helpers.HubKubeConfigSecret, "test", newKubeConfig(apiServerHost)),
 			},
 			allowToOperateManagedClusters: true,
 			klusterlet:                    newKlusterlet("testklusterlet", "test", ""),
 			expectedConditions: []operatorapiv1.StatusCondition{
-				testinghelper.NamedCondition(klusterletRegistrationDegraded, "ClusterNameMissing", metav1.ConditionTrue),
-				testinghelper.NamedCondition(klusterletWorKDegraded, "ClusterNameMissing", metav1.ConditionTrue),
+				testinghelper.NamedCondition(klusterletRegistrationDegraded, "ClusterNameMissing,GetDeploymentFailed", metav1.ConditionTrue),
+				testinghelper.NamedCondition(klusterletWorKDegraded, "ClusterNameMissing,GetDeploymentFailed", metav1.ConditionTrue),
 			},
 		},
 		{
@@ -227,8 +232,8 @@ func TestSync(t *testing.T) {
 			allowToOperateManagedClusters: true,
 			klusterlet:                    newKlusterlet("testklusterlet", "test", "cluster1"),
 			expectedConditions: []operatorapiv1.StatusCondition{
-				testinghelper.NamedCondition(klusterletRegistrationDegraded, "KubeConfigMissing", metav1.ConditionTrue),
-				testinghelper.NamedCondition(klusterletWorKDegraded, "KubeConfigMissing", metav1.ConditionTrue),
+				testinghelper.NamedCondition(klusterletRegistrationDegraded, "HubKubeConfigMissing,GetDeploymentFailed", metav1.ConditionTrue),
+				testinghelper.NamedCondition(klusterletWorKDegraded, "HubKubeConfigMissing,GetDeploymentFailed", metav1.ConditionTrue),
 			},
 		},
 		{
@@ -240,12 +245,12 @@ func TestSync(t *testing.T) {
 			allowToOperateManagedClusters: true,
 			klusterlet:                    newKlusterlet("testklusterlet", "test", "cluster1"),
 			expectedConditions: []operatorapiv1.StatusCondition{
-				testinghelper.NamedCondition(klusterletRegistrationDegraded, "HubConfigSecretError", metav1.ConditionTrue),
-				testinghelper.NamedCondition(klusterletWorKDegraded, "HubConfigSecretError", metav1.ConditionTrue),
+				testinghelper.NamedCondition(klusterletRegistrationDegraded, "HubKubeConfigError,GetDeploymentFailed", metav1.ConditionTrue),
+				testinghelper.NamedCondition(klusterletWorKDegraded, "HubKubeConfigError,GetDeploymentFailed", metav1.ConditionTrue),
 			},
 		},
 		{
-			name: "Unauthorized hub config secret (registration)",
+			name: "Unauthorized hub config secret",
 			object: []runtime.Object{
 				newSecretWithKubeConfig(helpers.BootstrapHubKubeConfigSecret, "test", newKubeConfig(apiServerHost)),
 				newSecretWithKubeConfig(helpers.HubKubeConfigSecret, "test", newKubeConfig(apiServerHost)),
@@ -253,20 +258,8 @@ func TestSync(t *testing.T) {
 			allowToOperateManagedClusters: true,
 			klusterlet:                    newKlusterlet("testklusterlet", "test", "cluster1"),
 			expectedConditions: []operatorapiv1.StatusCondition{
-				testinghelper.NamedCondition(klusterletRegistrationDegraded, "HubConfigSecretUnauthorized", metav1.ConditionTrue),
-			},
-		},
-		{
-			name: "Unauthorized hub config secret (work)",
-			object: []runtime.Object{
-				newSecretWithKubeConfig(helpers.BootstrapHubKubeConfigSecret, "test", newKubeConfig(apiServerHost)),
-				newSecretWithKubeConfig(helpers.HubKubeConfigSecret, "test", newKubeConfig(apiServerHost)),
-			},
-			allowToOperateManagedClusters:      true,
-			allowToOperateManagedClusterStatus: true,
-			klusterlet:                         newKlusterlet("testklusterlet", "test", "cluster1"),
-			expectedConditions: []operatorapiv1.StatusCondition{
-				testinghelper.NamedCondition(klusterletWorKDegraded, "HubConfigSecretUnauthorized", metav1.ConditionTrue),
+				testinghelper.NamedCondition(klusterletRegistrationDegraded, "HubKubeConfigUnauthorized,GetDeploymentFailed", metav1.ConditionTrue),
+				testinghelper.NamedCondition(klusterletWorKDegraded, "HubKubeConfigUnauthorized,GetDeploymentFailed", metav1.ConditionTrue),
 			},
 		},
 		{
@@ -282,8 +275,8 @@ func TestSync(t *testing.T) {
 			allowToOperateManifestWorks:        true,
 			klusterlet:                         newKlusterlet("testklusterlet", "test", "cluster1"),
 			expectedConditions: []operatorapiv1.StatusCondition{
-				testinghelper.NamedCondition(klusterletRegistrationDegraded, "UnavailableRegistrationPod", metav1.ConditionTrue),
-				testinghelper.NamedCondition(klusterletWorKDegraded, "UnavailableWorkPod", metav1.ConditionTrue),
+				testinghelper.NamedCondition(klusterletRegistrationDegraded, "UnavailablePods", metav1.ConditionTrue),
+				testinghelper.NamedCondition(klusterletWorKDegraded, "UnavailablePods", metav1.ConditionTrue),
 			},
 		},
 		{

--- a/test/integration/klusterlet_test.go
+++ b/test/integration/klusterlet_test.go
@@ -369,7 +369,8 @@ var _ = ginkgo.Describe("Klusterlet", func() {
 			_, err := operatorClient.OperatorV1().Klusterlets().Create(context.Background(), klusterlet, metav1.CreateOptions{})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-			util.AssertKlusterletCondition(klusterlet.Name, operatorClient, "KlusterletRegistrationDegraded", "BootStrapSecretMissing", metav1.ConditionTrue)
+			util.AssertKlusterletCondition(klusterlet.Name, operatorClient, "KlusterletRegistrationDegraded", "BootstrapSecretMissing,HubKubeConfigMissing,UnavailablePods", metav1.ConditionTrue)
+			util.AssertKlusterletCondition(klusterlet.Name, operatorClient, "KlusterletWorkDegraded", "HubKubeConfigMissing,UnavailablePods", metav1.ConditionTrue)
 
 			// Create a bootstrap secret and make sure the kubeconfig can work
 			bootStrapSecret := &corev1.Secret{
@@ -384,8 +385,8 @@ var _ = ginkgo.Describe("Klusterlet", func() {
 			_, err = kubeClient.CoreV1().Secrets(klusterletNamespace).Create(context.Background(), bootStrapSecret, metav1.CreateOptions{})
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
-			util.AssertKlusterletCondition(klusterlet.Name, operatorClient, "KlusterletRegistrationDegraded", "KubeConfigMissing", metav1.ConditionTrue)
-			util.AssertKlusterletCondition(klusterlet.Name, operatorClient, "KlusterletWorkDegraded", "KubeConfigMissing", metav1.ConditionTrue)
+			util.AssertKlusterletCondition(klusterlet.Name, operatorClient, "KlusterletRegistrationDegraded", "HubKubeConfigMissing,UnavailablePods", metav1.ConditionTrue)
+			util.AssertKlusterletCondition(klusterlet.Name, operatorClient, "KlusterletWorkDegraded", "HubKubeConfigMissing,UnavailablePods", metav1.ConditionTrue)
 
 			hubSecret, err := kubeClient.CoreV1().Secrets(klusterletNamespace).Get(context.Background(), helpers.HubKubeConfigSecret, metav1.GetOptions{})
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
@@ -396,8 +397,8 @@ var _ = ginkgo.Describe("Klusterlet", func() {
 			_, err = kubeClient.CoreV1().Secrets(klusterletNamespace).Update(context.Background(), hubSecret, metav1.UpdateOptions{})
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
-			util.AssertKlusterletCondition(klusterlet.Name, operatorClient, "KlusterletRegistrationDegraded", "UnavailableRegistrationPod", metav1.ConditionTrue)
-			util.AssertKlusterletCondition(klusterlet.Name, operatorClient, "KlusterletWorkDegraded", "UnavailableWorkPod", metav1.ConditionTrue)
+			util.AssertKlusterletCondition(klusterlet.Name, operatorClient, "KlusterletRegistrationDegraded", "UnavailablePods", metav1.ConditionTrue)
+			util.AssertKlusterletCondition(klusterlet.Name, operatorClient, "KlusterletWorkDegraded", "UnavailablePods", metav1.ConditionTrue)
 
 			// Update replica of deployment
 			registrationDeployment, err := kubeClient.AppsV1().Deployments(klusterletNamespace).Get(context.Background(), registrationDeploymentName, metav1.GetOptions{})


### PR DESCRIPTION
refactor degraded condition logic to make the code more clear and fix below problems:

1. after the bootstrap, the registration agent keeps working, but the bootstrap secret will be expired, the registration degraded condition will prompt `BootstrapSecretUnauthorized`
2. if the hub cluster-admin approve the csr, but does not accept the managed cluster, at this time point, the registration and work agent degraded conditions are not consistent, registration agent degraded condition is `HubConfigSecretUnauthorized`, but work agent degraded condition  is `KubeConfigMissing`