### PR TITLE
generate csv manifests

### DIFF
--- a/deploy/cluster-manager/olm-catalog/cluster-manager/0.1.0/0000_01_operator.open-cluster-management.io_clustermanagers.crd.yaml
+++ b/deploy/cluster-manager/olm-catalog/cluster-manager/0.1.0/0000_01_operator.open-cluster-management.io_clustermanagers.crd.yaml
@@ -1,0 +1,153 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: clustermanagers.operator.open-cluster-management.io
+spec:
+  group: operator.open-cluster-management.io
+  names:
+    kind: ClusterManager
+    listKind: ClusterManagerList
+    plural: clustermanagers
+    singular: clustermanager
+  scope: Cluster
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: ClusterManager configures the controllers on the hub that govern
+        registration and work distribution for attached Klusterlets. ClusterManager
+        will be only deployed in open-cluster-management-hub namespace.
+      type: object
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: Spec represents a desired deployment configuration of controllers
+            that govern registration and work distribution for attached Klusterlets.
+          type: object
+          properties:
+            registrationImagePullSpec:
+              description: RegistrationImagePullSpec represents the desired image
+                of registration controller installed on hub.
+              type: string
+        status:
+          description: Status represents the current status of controllers that govern
+            the lifecycle of managed clusters.
+          type: object
+          properties:
+            conditions:
+              description: 'Conditions contain the different condition statuses for
+                this ClusterManager. Valid condition types are: Applied: components
+                in hub are applied. Available: components in hub are available and
+                ready to serve. Progressing: components in hub are in a transitioning
+                state. Degraded: components in hub do not match the desired configuration
+                and only provide degraded service.'
+              type: array
+              items:
+                description: StatusCondition contains condition information.
+                type: object
+                properties:
+                  lastTransitionTime:
+                    description: LastTransitionTime is the last time the condition
+                      changed from one status to another.
+                    type: string
+                    format: date-time
+                  message:
+                    description: Message is a human-readable message indicating details
+                      about the last status change.
+                    type: string
+                  reason:
+                    description: Reason is a (brief) reason for the condition's last
+                      status change.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. One of True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the cluster condition.
+                    type: string
+            generations:
+              description: Generations are used to determine when an item needs to
+                be reconciled or has changed in a way that needs a reaction.
+              type: array
+              items:
+                description: GenerationStatus keeps track of the generation for a
+                  given resource so that decisions about forced updates can be made.
+                  the definition matches the GenerationStatus defined in github.com/openshift/api/v1
+                type: object
+                properties:
+                  group:
+                    description: group is the group of the thing you're tracking
+                    type: string
+                  lastGeneration:
+                    description: lastGeneration is the last generation of the thing
+                      that controller applies
+                    type: integer
+                    format: int64
+                  name:
+                    description: name is the name of the thing you're tracking
+                    type: string
+                  namespace:
+                    description: namespace is where the thing you're tracking is
+                    type: string
+                  resource:
+                    description: resource is the resource type of the thing you're
+                      tracking
+                    type: string
+                  version:
+                    description: version is the version of the thing you're tracking
+                    type: string
+            observedGeneration:
+              description: ObservedGeneration is the last generation change you've
+                dealt with
+              type: integer
+              format: int64
+            relatedResources:
+              description: RelatedResources are used to track the resources that are
+                related to this ClusterManager
+              type: array
+              items:
+                description: RelatedResourceMeta represents the resource that is managed
+                  by an operator
+                type: object
+                properties:
+                  group:
+                    description: group is the group of the thing you're tracking
+                    type: string
+                  name:
+                    description: name is the name of the thing you're tracking
+                    type: string
+                  namespace:
+                    description: namespace is where the thing you're tracking is
+                    type: string
+                  resource:
+                    description: resource is the resource type of the thing you're
+                      tracking
+                    type: string
+                  version:
+                    description: version is the version of the thing you're tracking
+                    type: string
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
+  preserveUnknownFields: false
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/deploy/cluster-manager/olm-catalog/cluster-manager/0.1.0/cluster-manager.v0.1.0.clusterserviceversion.yaml
+++ b/deploy/cluster-manager/olm-catalog/cluster-manager/0.1.0/cluster-manager.v0.1.0.clusterserviceversion.yaml
@@ -16,7 +16,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-  name: cluster-manager.v0.2.0
+  name: cluster-manager.v0.1.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -135,7 +135,6 @@ spec:
           - admissionregistration.k8s.io
           resources:
           - validatingwebhookconfigurations
-          - mutatingwebhookconfigurations
           verbs:
           - create
           - get
@@ -200,7 +199,7 @@ spec:
               - args:
                 - /registration-operator
                 - hub
-                image: quay.io/open-cluster-management/registration-operator:latest
+                image: quay.io/open-cluster-management/registration-operator:0.0.1
                 imagePullPolicy: IfNotPresent
                 livenessProbe:
                   httpGet:
@@ -238,5 +237,4 @@ spec:
   maturity: alpha
   provider:
     name: open-cluster-management
-  replaces: cluster-manager.v0.1.0
-  version: 0.2.0
+  version: 0.1.0

--- a/deploy/cluster-manager/olm-catalog/cluster-manager/cluster-manger.package.yaml
+++ b/deploy/cluster-manager/olm-catalog/cluster-manager/cluster-manger.package.yaml
@@ -1,0 +1,5 @@
+channels:
+  - name: stable
+    currentCSV: cluster-manager.v0.2.0
+defaultChannel: stable
+packageName: cluster-manager

--- a/deploy/klusterlet/olm-catalog/klusterlet/0.1.0/0000_00_operator.open-cluster-management.io_klusterlets.crd.yaml
+++ b/deploy/klusterlet/olm-catalog/klusterlet/0.1.0/0000_00_operator.open-cluster-management.io_klusterlets.crd.yaml
@@ -1,0 +1,188 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: klusterlets.operator.open-cluster-management.io
+spec:
+  group: operator.open-cluster-management.io
+  names:
+    kind: Klusterlet
+    listKind: KlusterletList
+    plural: klusterlets
+    singular: klusterlet
+  scope: Cluster
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: Klusterlet represents controllers on the managed cluster. When
+        configured, the Klusterlet requires a secret named of bootstrap-hub-kubeconfig
+        in the same namespace to allow API requests to the hub for the registration
+        protocol.
+      type: object
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: Spec represents the desired deployment configuration of Klusterlet
+            agent.
+          type: object
+          properties:
+            clusterName:
+              description: ClusterName is the name of the managed cluster to be created
+                on hub. The Klusterlet agent generates a random name if it is not
+                set, or discovers the appropriate cluster name on openshift.
+              type: string
+            externalServerURLs:
+              description: ExternalServerURLs represents the a list of apiserver urls
+                and ca bundles that is accessible externally If it is set empty, managed
+                cluster has no externally accessible url that hub cluster can visit.
+              type: array
+              items:
+                description: ServerURL represents the apiserver url and ca bundle
+                  that is accessible externally
+                type: object
+                properties:
+                  caBundle:
+                    description: CABundle is the ca bundle to connect to apiserver
+                      of the managed cluster. System certs are used if it is not set.
+                    type: string
+                    format: byte
+                  url:
+                    description: URL is the url of apiserver endpoint of the managed
+                      cluster.
+                    type: string
+            namespace:
+              description: Namespace is the namespace to deploy the agent. The namespace
+                must have a prefix of "open-cluster-management-", and if it is not
+                set, the namespace of "open-cluster-management-agent" is used to deploy
+                agent.
+              type: string
+            registrationImagePullSpec:
+              description: RegistrationImagePullSpec represents the desired image
+                configuration of registration agent.
+              type: string
+            workImagePullSpec:
+              description: WorkImagePullSpec represents the desired image configuration
+                of work agent.
+              type: string
+        status:
+          description: Status represents the current status of Klusterlet agent.
+          type: object
+          properties:
+            conditions:
+              description: 'Conditions contain the different condition statuses for
+                this Klusterlet. Valid condition types are: Applied: components have
+                been applied in the managed cluster. Available: components in the
+                managed cluster are available and ready to serve. Progressing: components
+                in the managed cluster are in a transitioning state. Degraded: components
+                in the managed cluster do not match the desired configuration and
+                only provide degraded service.'
+              type: array
+              items:
+                description: StatusCondition contains condition information.
+                type: object
+                properties:
+                  lastTransitionTime:
+                    description: LastTransitionTime is the last time the condition
+                      changed from one status to another.
+                    type: string
+                    format: date-time
+                  message:
+                    description: Message is a human-readable message indicating details
+                      about the last status change.
+                    type: string
+                  reason:
+                    description: Reason is a (brief) reason for the condition's last
+                      status change.
+                    type: string
+                  status:
+                    description: Status is the status of the condition. One of True,
+                      False, Unknown.
+                    type: string
+                  type:
+                    description: Type is the type of the cluster condition.
+                    type: string
+            generations:
+              description: Generations are used to determine when an item needs to
+                be reconciled or has changed in a way that needs a reaction.
+              type: array
+              items:
+                description: GenerationStatus keeps track of the generation for a
+                  given resource so that decisions about forced updates can be made.
+                  the definition matches the GenerationStatus defined in github.com/openshift/api/v1
+                type: object
+                properties:
+                  group:
+                    description: group is the group of the thing you're tracking
+                    type: string
+                  lastGeneration:
+                    description: lastGeneration is the last generation of the thing
+                      that controller applies
+                    type: integer
+                    format: int64
+                  name:
+                    description: name is the name of the thing you're tracking
+                    type: string
+                  namespace:
+                    description: namespace is where the thing you're tracking is
+                    type: string
+                  resource:
+                    description: resource is the resource type of the thing you're
+                      tracking
+                    type: string
+                  version:
+                    description: version is the version of the thing you're tracking
+                    type: string
+            observedGeneration:
+              description: ObservedGeneration is the last generation change you've
+                dealt with
+              type: integer
+              format: int64
+            relatedResources:
+              description: RelatedResources are used to track the resources that are
+                related to this Klusterlet
+              type: array
+              items:
+                description: RelatedResourceMeta represents the resource that is managed
+                  by an operator
+                type: object
+                properties:
+                  group:
+                    description: group is the group of the thing you're tracking
+                    type: string
+                  name:
+                    description: name is the name of the thing you're tracking
+                    type: string
+                  namespace:
+                    description: namespace is where the thing you're tracking is
+                    type: string
+                  resource:
+                    description: resource is the resource type of the thing you're
+                      tracking
+                    type: string
+                  version:
+                    description: version is the version of the thing you're tracking
+                    type: string
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
+  preserveUnknownFields: false
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/deploy/klusterlet/olm-catalog/klusterlet/0.1.0/klusterlet.v0.1.0.clusterserviceversion.yaml
+++ b/deploy/klusterlet/olm-catalog/klusterlet/0.1.0/klusterlet.v0.1.0.clusterserviceversion.yaml
@@ -6,29 +6,37 @@ metadata:
       [
         {
           "apiVersion": "operator.open-cluster-management.io/v1",
-          "kind": "ClusterManager",
+          "kind": "Klusterlet",
           "metadata": {
-            "name": "cluster-manager"
+            "name": "klusterlet"
           },
           "spec": {
-            "registrationImagePullSpec": "quay.io/open-cluster-management/registration"
+            "clusterName": "cluster1",
+            "externalServerURLs": [
+              {
+                "url": "https://localhost"
+              }
+            ],
+            "namespace": "open-cluster-management-agent",
+            "registrationImagePullSpec": "quay.io/open-cluster-management/registration",
+            "workImagePullSpec": "quay.io/open-cluster-management/work"
           }
         }
       ]
     capabilities: Basic Install
-  name: cluster-manager.v0.2.0
+  name: klusterlet.v0.1.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
     owned:
-    - description: ClusterManager defines the configurations of controllers running
-        hub that govern registration and work distribution for attached Klusterlets
-      displayName: ClusterManager
-      kind: ClusterManager
-      name: clustermanagers.operator.open-cluster-management.io
+    - description: Klusterlet defines the configurations of agents running on the
+        managed cluster
+      displayName: Klusterlet
+      kind: Klusterlet
+      name: klusterlets.operator.open-cluster-management.io
       version: v1
-  displayName: Cluster Manager
+  displayName: Klusterlet
   icon:
   - base64data: ""
     mediatype: ""
@@ -39,11 +47,9 @@ spec:
         - apiGroups:
           - ""
           resources:
-          - configmaps
-          - namespaces
-          - serviceaccounts
-          - services
           - secrets
+          - configmaps
+          - serviceaccounts
           verbs:
           - create
           - get
@@ -58,6 +64,15 @@ spec:
           - subjectaccessreviews
           verbs:
           - create
+        - apiGroups:
+          - ""
+          resources:
+          - namespaces
+          verbs:
+          - create
+          - get
+          - list
+          - watch
         - apiGroups:
           - ""
           - events.k8s.io
@@ -108,72 +123,36 @@ spec:
           - escalate
           - bind
         - apiGroups:
-          - apiextensions.k8s.io
+          - operator.open-cluster-management.io
           resources:
-          - customresourcedefinitions
+          - klusterlets
           verbs:
-          - create
           - get
           - list
-          - update
           - watch
-          - patch
-          - delete
-        - apiGroups:
-          - apiregistration.k8s.io
-          resources:
-          - apiservices
-          verbs:
-          - create
-          - get
-          - list
           - update
-          - watch
-          - patch
-          - delete
-        - apiGroups:
-          - admissionregistration.k8s.io
-          resources:
-          - validatingwebhookconfigurations
-          - mutatingwebhookconfigurations
-          verbs:
-          - create
-          - get
-          - list
-          - update
-          - watch
           - patch
           - delete
         - apiGroups:
           - operator.open-cluster-management.io
           resources:
-          - clustermanagers
-          verbs:
-          - get
-          - list
-          - watch
-          - update
-          - delete
-        - apiGroups:
-          - operator.open-cluster-management.io
-          resources:
-          - clustermanagers/status
+          - klusterlets/status
           verbs:
           - update
           - patch
-        serviceAccountName: cluster-manager
+        serviceAccountName: klusterlet
       deployments:
-      - name: cluster-manager
+      - name: klusterlet
         spec:
           replicas: 3
           selector:
             matchLabels:
-              app: cluster-manager
+              app: klusterlet
           strategy: {}
           template:
             metadata:
               labels:
-                app: cluster-manager
+                app: klusterlet
             spec:
               affinity:
                 podAntiAffinity:
@@ -184,7 +163,7 @@ spec:
                         - key: app
                           operator: In
                           values:
-                          - cluster-manager
+                          - klusterlet
                       topologyKey: failure-domain.beta.kubernetes.io/zone
                     weight: 70
                   - podAffinityTerm:
@@ -193,14 +172,14 @@ spec:
                         - key: app
                           operator: In
                           values:
-                          - cluster-manager
+                          - klusterlet
                       topologyKey: kubernetes.io/hostname
                     weight: 30
               containers:
               - args:
                 - /registration-operator
-                - hub
-                image: quay.io/open-cluster-management/registration-operator:latest
+                - klusterlet
+                image: quay.io/open-cluster-management/registration-operator:0.0.1
                 imagePullPolicy: IfNotPresent
                 livenessProbe:
                   httpGet:
@@ -209,7 +188,7 @@ spec:
                     scheme: HTTPS
                   initialDelaySeconds: 2
                   periodSeconds: 10
-                name: registration-operator
+                name: klusterlet
                 readinessProbe:
                   httpGet:
                     path: /healthz
@@ -220,7 +199,7 @@ spec:
                   requests:
                     cpu: 100m
                     memory: 128Mi
-              serviceAccountName: cluster-manager
+              serviceAccountName: klusterlet
     strategy: deployment
   installModes:
   - supported: true
@@ -236,7 +215,5 @@ spec:
   maintainers:
   - {}
   maturity: alpha
-  provider:
-    name: open-cluster-management
-  replaces: cluster-manager.v0.1.0
-  version: 0.2.0
+  provider: {}
+  version: 0.1.0

--- a/deploy/klusterlet/olm-catalog/klusterlet/klusterlet.package.yaml
+++ b/deploy/klusterlet/olm-catalog/klusterlet/klusterlet.package.yaml
@@ -1,0 +1,5 @@
+channels:
+- currentCSV: klusterlet.v0.2.0
+  name: stable
+defaultChannel: stable
+packageName: klusterlet

--- a/deploy/klusterlet/olm-catalog/klusterlet/manifests/klusterlet.clusterserviceversion.yaml
+++ b/deploy/klusterlet/olm-catalog/klusterlet/manifests/klusterlet.clusterserviceversion.yaml
@@ -24,7 +24,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-  name: klusterlet.v0.1.0
+  name: klusterlet.v0.2.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -228,4 +228,5 @@ spec:
   - {}
   maturity: alpha
   provider: {}
-  version: 0.1.0
+  replaces: klusterlet.v0.1.0
+  version: 0.2.0


### PR DESCRIPTION
upgrade the csv to version 0.2.0 and generate the csv manifests.

`olm-catalog/0.1.0` is associated with the 0.0.1 image tag (release 2.0).
`olm-catalog/manifests` is 0.2.0 which is associated with the latest image tag. 