### PR TITLE
delete imagePullPolicy

### DIFF
--- a/deploy/cluster-manager/olm-catalog/cluster-manager/manifests/cluster-manager.clusterserviceversion.yaml
+++ b/deploy/cluster-manager/olm-catalog/cluster-manager/manifests/cluster-manager.clusterserviceversion.yaml
@@ -236,7 +236,6 @@ spec:
                 - /registration-operator
                 - hub
                 image: quay.io/open-cluster-management/registration-operator:latest
-                imagePullPolicy: IfNotPresent
                 livenessProbe:
                   httpGet:
                     path: /healthz

--- a/deploy/cluster-manager/operator.yaml
+++ b/deploy/cluster-manager/operator.yaml
@@ -40,7 +40,6 @@ spec:
       containers:
       - name: registration-operator
         image: quay.io/open-cluster-management/registration-operator:latest
-        imagePullPolicy: IfNotPresent
         args:
           - "/registration-operator"
           - "hub"

--- a/deploy/klusterlet/olm-catalog/klusterlet/manifests/klusterlet.clusterserviceversion.yaml
+++ b/deploy/klusterlet/olm-catalog/klusterlet/manifests/klusterlet.clusterserviceversion.yaml
@@ -237,7 +237,6 @@ spec:
                 - /registration-operator
                 - klusterlet
                 image: quay.io/open-cluster-management/registration-operator:latest
-                imagePullPolicy: IfNotPresent
                 livenessProbe:
                   httpGet:
                     path: /healthz

--- a/deploy/klusterlet/operator.yaml
+++ b/deploy/klusterlet/operator.yaml
@@ -40,7 +40,6 @@ spec:
       containers:
       - name: klusterlet
         image: quay.io/open-cluster-management/registration-operator:latest
-        imagePullPolicy: IfNotPresent
         args:
           - "/registration-operator"
           - "klusterlet"

--- a/manifests/cluster-manager/cluster-manager-registration-deployment.yaml
+++ b/manifests/cluster-manager/cluster-manager-registration-deployment.yaml
@@ -40,7 +40,6 @@ spec:
       containers:
       - name: hub-registration-controller
         image: {{ .RegistrationImage }}
-        imagePullPolicy: IfNotPresent
         args:
           - "/registration"
           - "controller"

--- a/manifests/cluster-manager/cluster-manager-registration-webhook-deployment.yaml
+++ b/manifests/cluster-manager/cluster-manager-registration-webhook-deployment.yaml
@@ -40,7 +40,6 @@ spec:
       containers:
       - name: {{ .ClusterManagerName }}-registration-webhook-sa
         image: {{ .RegistrationImage }}
-        imagePullPolicy: IfNotPresent
         args:
           - "/registration"
           - "webhook"

--- a/manifests/cluster-manager/cluster-manager-work-webhook-deployment.yaml
+++ b/manifests/cluster-manager/cluster-manager-work-webhook-deployment.yaml
@@ -40,7 +40,6 @@ spec:
       containers:
       - name: {{ .ClusterManagerName }}-work-webhook-sa
         image: {{ .WorkImage }}
-        imagePullPolicy: IfNotPresent
         args:
           - "/work"
           - "webhook"

--- a/manifests/klusterlet/klusterlet-registration-deployment.yaml
+++ b/manifests/klusterlet/klusterlet-registration-deployment.yaml
@@ -40,7 +40,6 @@ spec:
       containers:
       - name: registration-controller
         image: {{ .RegistrationImage }}
-        imagePullPolicy: IfNotPresent
         args:
           - "/registration"
           - "agent"

--- a/manifests/klusterlet/klusterlet-work-deployment.yaml
+++ b/manifests/klusterlet/klusterlet-work-deployment.yaml
@@ -40,7 +40,6 @@ spec:
       containers:
       - name: klusterlet-manifestwork-agent
         image: {{ .WorkImage }}
-        imagePullPolicy: IfNotPresent
         args:
           - "/work"
           - "agent"

--- a/pkg/operators/clustermanager/bindata/bindata.go
+++ b/pkg/operators/clustermanager/bindata/bindata.go
@@ -991,7 +991,6 @@ spec:
       containers:
       - name: hub-registration-controller
         image: {{ .RegistrationImage }}
-        imagePullPolicy: IfNotPresent
         args:
           - "/registration"
           - "controller"
@@ -1225,7 +1224,6 @@ spec:
       containers:
       - name: {{ .ClusterManagerName }}-registration-webhook-sa
         image: {{ .RegistrationImage }}
-        imagePullPolicy: IfNotPresent
         args:
           - "/registration"
           - "webhook"
@@ -1569,7 +1567,6 @@ spec:
       containers:
       - name: {{ .ClusterManagerName }}-work-webhook-sa
         image: {{ .WorkImage }}
-        imagePullPolicy: IfNotPresent
         args:
           - "/work"
           - "webhook"

--- a/pkg/operators/klusterlet/bindata/bindata.go
+++ b/pkg/operators/klusterlet/bindata/bindata.go
@@ -288,7 +288,6 @@ spec:
       containers:
       - name: registration-controller
         image: {{ .RegistrationImage }}
-        imagePullPolicy: IfNotPresent
         args:
           - "/registration"
           - "agent"
@@ -586,7 +585,6 @@ spec:
       containers:
       - name: klusterlet-manifestwork-agent
         image: {{ .WorkImage }}
-        imagePullPolicy: IfNotPresent
         args:
           - "/work"
           - "agent"


### PR DESCRIPTION
delete `imagePullPolicy: IfNotPresent` in the deployments to make sure that the latest images are pulled when the image tag is `latest` or omitted.

>refer the doc https://kubernetes.io/docs/concepts/configuration/overview/ 
>
>imagePullPolicy is omitted and either the image tag is :latest or it is omitted: Always is applied.
>imagePullPolicy is omitted and the image tag is present but not :latest: IfNotPresent is applied.
