### PR TITLE
upgrade operator-sdk to v1.1.0

### DIFF
--- a/deploy/cluster-manager/olm-catalog/cluster-manager/manifests/cluster-manager.clusterserviceversion.yaml
+++ b/deploy/cluster-manager/olm-catalog/cluster-manager/manifests/cluster-manager.clusterserviceversion.yaml
@@ -22,7 +22,7 @@ metadata:
     containerImage: quay.io/repository/open-cluster-management/registration-operator:latest
     createdAt: "2020-10-15T20:00:31Z"
     description: Manages the installation and upgrade of the ClusterManager.
-    operators.operatorframework.io/builder: operator-sdk-v1.0.1
+    operators.operatorframework.io/builder: operator-sdk-v1.1.0
     operators.operatorframework.io/project_layout: go
     repository: https://github.com/open-cluster-management/registration-operator
     support: Red Hat, Inc.
@@ -256,9 +256,6 @@ spec:
                     cpu: 100m
                     memory: 128Mi
               serviceAccountName: cluster-manager
-      permissions:
-      - rules: []
-        serviceAccountName: cluster-manager
     strategy: deployment
   installModes:
   - supported: true

--- a/deploy/klusterlet/olm-catalog/klusterlet/manifests/klusterlet.clusterserviceversion.yaml
+++ b/deploy/klusterlet/olm-catalog/klusterlet/manifests/klusterlet.clusterserviceversion.yaml
@@ -29,7 +29,7 @@ metadata:
     containerImage: quay.io/repository/open-cluster-management/registration-operator:latest
     createdAt: "2020-10-15T20:00:31Z"
     description: Manages the installation and upgrade of the Klusterlet.
-    operators.operatorframework.io/builder: operator-sdk-v1.0.1
+    operators.operatorframework.io/builder: operator-sdk-v1.1.0
     operators.operatorframework.io/project_layout: go
     repository: https://github.com/open-cluster-management/registration-operator
     support: Red Hat, Inc.
@@ -257,9 +257,6 @@ spec:
                     cpu: 100m
                     memory: 128Mi
               serviceAccountName: klusterlet
-      permissions:
-      - rules: []
-        serviceAccountName: klusterlet
     strategy: deployment
   installModes:
   - supported: true


### PR DESCRIPTION
Signed-off-by: Zhiwei Yin <zyin@redhat.com>

upgrade operator-sdk to v1.1.0 to fix null slice issue (https://github.com/operator-framework/operator-sdk/issues/4041)