### PR TITLE
Add management workload annotations

### DIFF
--- a/deploy/klusterlet/config/operator/namespace.yaml
+++ b/deploy/klusterlet/config/operator/namespace.yaml
@@ -1,4 +1,6 @@
 apiVersion: v1
 kind: Namespace
 metadata:
+  annotations:
+    workload.openshift.io/allowed: "management"
   name: open-cluster-management

--- a/deploy/klusterlet/config/operator/operator.yaml
+++ b/deploy/klusterlet/config/operator/operator.yaml
@@ -12,6 +12,8 @@ spec:
       app: klusterlet
   template:
     metadata:
+      annotations:
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: klusterlet
     spec:

--- a/deploy/klusterlet/olm-catalog/klusterlet/manifests/klusterlet.clusterserviceversion.yaml
+++ b/deploy/klusterlet/olm-catalog/klusterlet/manifests/klusterlet.clusterserviceversion.yaml
@@ -209,6 +209,8 @@ spec:
           strategy: {}
           template:
             metadata:
+              annotations:
+                target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
               labels:
                 app: klusterlet
             spec:

--- a/manifests/klusterlet/klusterlet-registration-deployment.yaml
+++ b/manifests/klusterlet/klusterlet-registration-deployment.yaml
@@ -12,6 +12,8 @@ spec:
       app: klusterlet-registration-agent
   template:
     metadata:
+      annotations:
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: klusterlet-registration-agent
     spec:

--- a/manifests/klusterlet/klusterlet-work-deployment.yaml
+++ b/manifests/klusterlet/klusterlet-work-deployment.yaml
@@ -12,6 +12,8 @@ spec:
       app: klusterlet-manifestwork-agent
   template:
     metadata:
+      annotations:
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: klusterlet-manifestwork-agent
     spec:

--- a/pkg/operators/klusterlet/bindata/bindata.go
+++ b/pkg/operators/klusterlet/bindata/bindata.go
@@ -538,6 +538,8 @@ spec:
       app: klusterlet-registration-agent
   template:
     metadata:
+      annotations:
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: klusterlet-registration-agent
     spec:
@@ -843,6 +845,8 @@ spec:
       app: klusterlet-manifestwork-agent
   template:
     metadata:
+      annotations:
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: klusterlet-manifestwork-agent
     spec:

--- a/pkg/operators/klusterlet/controllers/klusterletcontroller/klusterlet_controller.go
+++ b/pkg/operators/klusterlet/controllers/klusterletcontroller/klusterlet_controller.go
@@ -186,7 +186,12 @@ func (n *klusterletController) sync(ctx context.Context, controllerContext facto
 	switch {
 	case errors.IsNotFound(err):
 		_, createErr := n.kubeClient.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{
-			ObjectMeta: metav1.ObjectMeta{Name: config.KlusterletNamespace},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: config.KlusterletNamespace,
+				Annotations: map[string]string{
+					"workload.openshift.io/allowed": "management",
+				},
+			},
 		}, metav1.CreateOptions{})
 		if createErr != nil {
 			_, _, _ = helpers.UpdateKlusterletStatus(ctx, n.klusterletClient, klusterletName, helpers.UpdateKlusterletConditionFn(metav1.Condition{

--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -169,6 +169,9 @@ func (t *Tester) CreateKlusterlet(name, clusterName, agentNamespace string) (*op
 	namespace := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: agentNamespace,
+			Annotations: map[string]string{
+				"workload.openshift.io/allowed": "management",
+			},
 		},
 	}
 	if _, err := t.KubeClient.CoreV1().Namespaces().Get(context.TODO(), agentNamespace, metav1.GetOptions{}); err != nil {


### PR DESCRIPTION
In support of the workload partitioning feature
(openshift/enhancements#703), we need to add
annotations to all management pods and namespaces so they can be
properly identified and assigned to segregated management cores on
clusters configured to do so.

Signed-off-by: Ian Miller <imiller@redhat.com>