### PR TITLE
use a more appropriate name for github action that publish the built image

### DIFF
--- a/.github/workflows/go-postsubmit.yml
+++ b/.github/workflows/go-postsubmit.yml
@@ -17,7 +17,7 @@ defaults:
     working-directory: go/src/open-cluster-management.io/registration-operator
 
 jobs:
-  verify:
+  images:
     name: images
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
With my limited knowledge of GitHub actions, I am assuming this value can be changed to a more fitting name.

Signed-off-by: Mike Ng <ming@redhat.com>