### PR TITLE
Modify <What is next> approve csr related content

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,16 +91,18 @@ We mainly provide deployment in two scenarios:
 After a successful deployment, a `certificatesigningrequest` and a `managedcluster` will
 be created on the hub.
 
+
+Switch to hub context and deploy hub components.
 ```
+kubectl config use-context {hub-context}
 kubectl get csr
-kubectl get managedcluster
 ```
 
 Next approve the csr and set managedCluster to be accepted by hub with the following command
-
 ```
 kubectl certificate approve {csr name}
 kubectl patch managedcluster {cluster name} -p='{"spec":{"hubAcceptsClient":true}}' --type=merge
+kubectl get managedcluster
 ```
 
 ## Community, discussion, contribution, and support

--- a/pkg/operators/klusterlet/controllers/ssarcontroller/klusterlet_ssar_controller_test.go
+++ b/pkg/operators/klusterlet/controllers/ssarcontroller/klusterlet_ssar_controller_test.go
@@ -157,12 +157,11 @@ func TestSync(t *testing.T) {
 				newSecretWithKubeConfig(helpers.HubKubeConfig, "test", newKubeConfig(apiServerHost)),
 			},
 			klusterlet:                         newKlusterlet("testklusterlet", "test", "cluster1"),
-			allowToOperateManagedClusters:      true,
-			allowToOperateManagedClusterStatus: true,
-			allowToOperateManifestWorks:        true,
+			allowToOperateManagedClusters:      false,
+			allowToOperateManagedClusterStatus: false,
+			allowToOperateManifestWorks:        false,
 			expectedConditions: []metav1.Condition{
-				testinghelper.NamedCondition(bootstrapSecretDegraded, "BootstrapSecretMissing", metav1.ConditionTrue),
-				testinghelper.NamedCondition(hubConfigSecretDegraded, "HubConfigSecretFunctional", metav1.ConditionFalse),
+				testinghelper.NamedCondition(hubConnectionDegraded, "BootstrapSecretMissing,HubKubeConfigUnauthorized", metav1.ConditionTrue),
 			},
 		},
 		{
@@ -175,8 +174,7 @@ func TestSync(t *testing.T) {
 			allowToOperateManagedClusterStatus: true,
 			allowToOperateManifestWorks:        true,
 			expectedConditions: []metav1.Condition{
-				testinghelper.NamedCondition(bootstrapSecretDegraded, "BootstrapSecretFunctional", metav1.ConditionFalse),
-				testinghelper.NamedCondition(hubConfigSecretDegraded, "HubKubeConfigSecretMissing", metav1.ConditionTrue),
+				testinghelper.NamedCondition(hubConnectionDegraded, "BootstrapSecretFunctional,HubKubeConfigSecretMissing", metav1.ConditionTrue),
 			},
 		},
 		{
@@ -185,13 +183,12 @@ func TestSync(t *testing.T) {
 				newSecretWithKubeConfig(helpers.BootstrapHubKubeConfig, "test", []byte("badsecret")),
 				newSecretWithKubeConfig(helpers.HubKubeConfig, "test", newKubeConfig(apiServerHost)),
 			},
-			allowToOperateManagedClusters:      true,
-			allowToOperateManagedClusterStatus: true,
-			allowToOperateManifestWorks:        true,
+			allowToOperateManagedClusters:      false,
+			allowToOperateManagedClusterStatus: false,
+			allowToOperateManifestWorks:        false,
 			klusterlet:                         newKlusterlet("testklusterlet", "test", "cluster1"),
 			expectedConditions: []metav1.Condition{
-				testinghelper.NamedCondition(bootstrapSecretDegraded, "BootstrapSecretError", metav1.ConditionTrue),
-				testinghelper.NamedCondition(hubConfigSecretDegraded, "HubConfigSecretFunctional", metav1.ConditionFalse),
+				testinghelper.NamedCondition(hubConnectionDegraded, "BootstrapSecretError,HubKubeConfigUnauthorized", metav1.ConditionTrue),
 			},
 		},
 		{
@@ -205,8 +202,7 @@ func TestSync(t *testing.T) {
 			allowToOperateManifestWorks:        true,
 			klusterlet:                         newKlusterlet("testklusterlet", "test", "cluster1"),
 			expectedConditions: []metav1.Condition{
-				testinghelper.NamedCondition(bootstrapSecretDegraded, "BootstrapSecretFunctional", metav1.ConditionFalse),
-				testinghelper.NamedCondition(hubConfigSecretDegraded, "HubKubeConfigError", metav1.ConditionTrue),
+				testinghelper.NamedCondition(hubConnectionDegraded, "BootstrapSecretFunctional,HubKubeConfigError", metav1.ConditionTrue),
 			},
 		},
 		{
@@ -220,8 +216,7 @@ func TestSync(t *testing.T) {
 			allowToOperateManifestWorks:        false,
 			klusterlet:                         newKlusterlet("testklusterlet", "test", "cluster1"),
 			expectedConditions: []metav1.Condition{
-				testinghelper.NamedCondition(bootstrapSecretDegraded, "BootstrapSecretUnauthorized", metav1.ConditionTrue),
-				testinghelper.NamedCondition(hubConfigSecretDegraded, "HubKubeConfigUnauthorized", metav1.ConditionTrue),
+				testinghelper.NamedCondition(hubConnectionDegraded, "BootstrapSecretUnauthorized,HubKubeConfigUnauthorized", metav1.ConditionTrue),
 			},
 		},
 		{
@@ -235,8 +230,7 @@ func TestSync(t *testing.T) {
 			allowToOperateManifestWorks:        true,
 			klusterlet:                         newKlusterlet("testklusterlet", "test", "cluster1"),
 			expectedConditions: []metav1.Condition{
-				testinghelper.NamedCondition(bootstrapSecretDegraded, "BootstrapSecretFunctional", metav1.ConditionFalse),
-				testinghelper.NamedCondition(hubConfigSecretDegraded, "HubConfigSecretFunctional", metav1.ConditionFalse),
+				testinghelper.NamedCondition(hubConnectionDegraded, "HubConnectionFunctional", metav1.ConditionFalse),
 			},
 		},
 	}

--- a/test/integration/integration_suite_test.go
+++ b/test/integration/integration_suite_test.go
@@ -21,6 +21,7 @@ import (
 	operatorclient "open-cluster-management.io/api/client/operator/clientset/versioned"
 	operatorapiv1 "open-cluster-management.io/api/operator/v1"
 	"open-cluster-management.io/registration-operator/pkg/operators/klusterlet/controllers/bootstrapcontroller"
+	"open-cluster-management.io/registration-operator/pkg/operators/klusterlet/controllers/ssarcontroller"
 )
 
 func TestIntegration(t *testing.T) {
@@ -51,6 +52,7 @@ var _ = ginkgo.BeforeSuite(func(done ginkgo.Done) {
 
 	// crank up the sync speed
 	bootstrapcontroller.BootstrapControllerSyncInterval = 2 * time.Second
+	ssarcontroller.SSARReSyncTime = 1 * time.Second
 
 	var err error
 


### PR DESCRIPTION
Signed-off-by: wangglbj <wangglbj@cn.ibm.com> Modified the following two aspects:

1. Switch to hub context before get csr.
2. Only after the patch is completed can valid information be obtained of managedcluster.
@zhiweiyin318  could you help to review again. thanks