### PR TITLE
update relatedResources in clusterManager and kluterlerlet

### DIFF
--- a/test/integration/clustermanager_test.go
+++ b/test/integration/clustermanager_test.go
@@ -261,6 +261,19 @@ var _ = ginkgo.Describe("ClusterManager", func() {
 
 				return true
 			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeTrue())
+
+			// Check if relatedResources are correct
+			gomega.Eventually(func() error {
+				actual, err := operatorClient.OperatorV1().ClusterManagers().Get(context.Background(), clusterManagerName, metav1.GetOptions{})
+				if err != nil {
+					return err
+				}
+				if len(actual.Status.RelatedResources) != 33 {
+					return fmt.Errorf("should get 33 relatedResources, actual got %v", len(actual.Status.RelatedResources))
+				}
+				return nil
+			}, eventuallyTimeout, eventuallyInterval).ShouldNot(gomega.HaveOccurred())
+
 		})
 
 		ginkgo.It("Deployment should be added nodeSelector and toleration when add nodePlacement into clustermanager", func() {

--- a/test/integration/klusterlet_test.go
+++ b/test/integration/klusterlet_test.go
@@ -100,6 +100,18 @@ var _ = ginkgo.Describe("Klusterlet", func() {
 			_, err := operatorClient.OperatorV1().Klusterlets().Create(context.Background(), klusterlet, metav1.CreateOptions{})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
+			// Check if relatedResources are correct
+			gomega.Eventually(func() error {
+				actual, err := operatorClient.OperatorV1().Klusterlets().Get(context.Background(), klusterlet.Name, metav1.GetOptions{})
+				if err != nil {
+					return err
+				}
+				if len(actual.Status.RelatedResources) != 13 {
+					return fmt.Errorf("should get 13 relatedResources, actual got %v", len(actual.Status.RelatedResources))
+				}
+				return nil
+			}, eventuallyTimeout, eventuallyInterval).ShouldNot(gomega.HaveOccurred())
+
 			// Check clusterrole/clusterrolebinding
 			gomega.Eventually(func() bool {
 				if _, err := kubeClient.RbacV1().ClusterRoles().Get(context.Background(), registrationRoleName, metav1.GetOptions{}); err != nil {


### PR DESCRIPTION
issue: https://github.com/open-cluster-management-io/registration-operator/issues/159
Signed-off-by: Zhiwei Yin <zyin@redhat.com>

in the `status` of clustermanager and klusterlet, `generations` filed only has deployed deployments, `relatedResources` filed has all related resources.