### PR TITLE
line 48: modified the assignment symbol for HUB_KUBECONFIG

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ kustomize_dir:=$(dir $(KUSTOMIZE))
 
 KUBECTL?=kubectl
 KUBECONFIG?=./.kubeconfig
-HUB_KUBECONFIG=./.hub-kubeconfig
+HUB_KUBECONFIG?=./.hub-kubeconfig
 
 OPERATOR_SDK_ARCHOS:=x86_64-linux-gnu
 ifeq ($(GOHOSTOS),darwin)


### PR DESCRIPTION
Signed-off-by: ycyaoxdu <yaoyuchen0626@163.com>

While running `make deploy-spoke` in the link https://open-cluster-management.io/getting-started/core/register-cluster/#install-from-source to deploy `agent` in cluster named `kind-cluster1`, the value of environment variable `HUB_KUBECONFIG`, which is set in the command `export HUB_KUBECONFIG=<your hub cluster kubeconfig file>    # export HUB_KUBECONFIG=~/hub-kubeconfig` in the link https://open-cluster-management.io/getting-started/core/cluster-manager/#prerequisite , specifing the configuration file of `hub`, is covered by the value of `HUB_KUBECONFIG` defined by the command `HUB_KUBECONFIG=./.hub-kubeconfig` in Makefile, line:48. Causing the deployment of `agent` to fail. 

To avoid this, it is more appropriate to change the assignment symbol, `=`, into `?=`.
