### PR TITLE
Support customize cluster manager namespace

### DIFF
--- a/deploy/cluster-manager/config/samples/operator_open-cluster-management_clustermanagers.cr.yaml
+++ b/deploy/cluster-manager/config/samples/operator_open-cluster-management_clustermanagers.cr.yaml
@@ -6,3 +6,5 @@ spec:
   registrationImagePullSpec: quay.io/open-cluster-management/registration
   workImagePullSpec: quay.io/open-cluster-management/work
   placementImagePullSpec: quay.io/open-cluster-management/placement
+  deployOption:
+    mode: Default

--- a/deploy/cluster-manager/olm-catalog/cluster-manager/manifests/cluster-manager.clusterserviceversion.yaml
+++ b/deploy/cluster-manager/olm-catalog/cluster-manager/manifests/cluster-manager.clusterserviceversion.yaml
@@ -11,6 +11,9 @@ metadata:
             "name": "cluster-manager"
           },
           "spec": {
+            "deployOption": {
+              "mode": "Default"
+            },
             "placementImagePullSpec": "quay.io/open-cluster-management/placement",
             "registrationImagePullSpec": "quay.io/open-cluster-management/registration",
             "workImagePullSpec": "quay.io/open-cluster-management/work"

--- a/deploy/klusterlet/olm-catalog/klusterlet/manifests/klusterlet.clusterserviceversion.yaml
+++ b/deploy/klusterlet/olm-catalog/klusterlet/manifests/klusterlet.clusterserviceversion.yaml
@@ -209,6 +209,13 @@ spec:
           verbs:
           - update
           - patch
+        - apiGroups:
+          - work.open-cluster-management.io
+          resources:
+          - appliedmanifestworks
+          verbs:
+          - list
+          - update
         serviceAccountName: klusterlet
       deployments:
       - name: klusterlet

--- a/manifests/cluster-manager/cluster-manager-namespace.yaml
+++ b/manifests/cluster-manager/cluster-manager-namespace.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: open-cluster-management-hub
+  name: {{ .ClusterManagerNamespace }}

--- a/manifests/cluster-manager/cluster-manager-placement-clusterrolebinding.yaml
+++ b/manifests/cluster-manager/cluster-manager-placement-clusterrolebinding.yaml
@@ -8,5 +8,5 @@ roleRef:
   name: open-cluster-management:{{ .ClusterManagerName }}-placement:controller
 subjects:
 - kind: ServiceAccount
-  namespace: open-cluster-management-hub
+  namespace: {{ .ClusterManagerNamespace }}
   name: {{ .ClusterManagerName }}-placement-controller-sa

--- a/manifests/cluster-manager/cluster-manager-placement-deployment.yaml
+++ b/manifests/cluster-manager/cluster-manager-placement-deployment.yaml
@@ -2,7 +2,7 @@ kind: Deployment
 apiVersion: apps/v1
 metadata:
   name: {{ .ClusterManagerName }}-placement-controller
-  namespace: open-cluster-management-hub
+  namespace: {{ .ClusterManagerNamespace }}
   labels:
     app: clustermanager-controller
 spec:

--- a/manifests/cluster-manager/cluster-manager-placement-serviceaccount.yaml
+++ b/manifests/cluster-manager/cluster-manager-placement-serviceaccount.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ .ClusterManagerName }}-placement-controller-sa
-  namespace: open-cluster-management-hub
+  namespace: {{ .ClusterManagerNamespace }}

--- a/manifests/cluster-manager/cluster-manager-registration-clusterrolebinding.yaml
+++ b/manifests/cluster-manager/cluster-manager-registration-clusterrolebinding.yaml
@@ -8,5 +8,5 @@ roleRef:
   name: open-cluster-management:{{ .ClusterManagerName }}-registration:controller
 subjects:
 - kind: ServiceAccount
-  namespace: open-cluster-management-hub
+  namespace: {{ .ClusterManagerNamespace }}
   name: {{ .ClusterManagerName }}-registration-controller-sa

--- a/manifests/cluster-manager/cluster-manager-registration-deployment.yaml
+++ b/manifests/cluster-manager/cluster-manager-registration-deployment.yaml
@@ -2,7 +2,7 @@ kind: Deployment
 apiVersion: apps/v1
 metadata:
   name: {{ .ClusterManagerName }}-registration-controller
-  namespace: open-cluster-management-hub
+  namespace: {{ .ClusterManagerNamespace }}
   labels:
     app: clustermanager-controller
 spec:

--- a/manifests/cluster-manager/cluster-manager-registration-serviceaccount.yaml
+++ b/manifests/cluster-manager/cluster-manager-registration-serviceaccount.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ .ClusterManagerName }}-registration-controller-sa
-  namespace: open-cluster-management-hub
+  namespace: {{ .ClusterManagerNamespace }}

--- a/manifests/cluster-manager/cluster-manager-registration-webhook-apiservice.yaml
+++ b/manifests/cluster-manager/cluster-manager-registration-webhook-apiservice.yaml
@@ -7,7 +7,7 @@ spec:
   version: v1
   service:
     name: cluster-manager-registration-webhook
-    namespace: open-cluster-management-hub
+    namespace: {{ .ClusterManagerNamespace }}
     port: 443
   caBundle: {{ .RegistrationAPIServiceCABundle }}
   groupPriorityMinimum: 10000

--- a/manifests/cluster-manager/cluster-manager-registration-webhook-clusterrolebinding.yaml
+++ b/manifests/cluster-manager/cluster-manager-registration-webhook-clusterrolebinding.yaml
@@ -9,4 +9,4 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ .ClusterManagerName }}-registration-webhook-sa
-    namespace: open-cluster-management-hub
+    namespace: {{ .ClusterManagerNamespace }}

--- a/manifests/cluster-manager/cluster-manager-registration-webhook-deployment.yaml
+++ b/manifests/cluster-manager/cluster-manager-registration-webhook-deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .ClusterManagerName }}-registration-webhook
-  namespace: open-cluster-management-hub
+  namespace: {{ .ClusterManagerNamespace }}
   labels:
     app: {{ .ClusterManagerName }}-registration-webhook
 spec:

--- a/manifests/cluster-manager/cluster-manager-registration-webhook-service.yaml
+++ b/manifests/cluster-manager/cluster-manager-registration-webhook-service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: cluster-manager-registration-webhook
-  namespace: open-cluster-management-hub
+  namespace: {{ .ClusterManagerNamespace }}
 spec:
   selector:
     app: {{ .ClusterManagerName }}-registration-webhook

--- a/manifests/cluster-manager/cluster-manager-registration-webhook-serviceaccount.yaml
+++ b/manifests/cluster-manager/cluster-manager-registration-webhook-serviceaccount.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ .ClusterManagerName }}-registration-webhook-sa
-  namespace: open-cluster-management-hub
+  namespace: {{ .ClusterManagerNamespace }}

--- a/manifests/cluster-manager/cluster-manager-work-webhook-apiservice.yaml
+++ b/manifests/cluster-manager/cluster-manager-work-webhook-apiservice.yaml
@@ -7,7 +7,7 @@ spec:
   version: v1
   service:
     name: cluster-manager-work-webhook
-    namespace: open-cluster-management-hub
+    namespace: {{ .ClusterManagerNamespace }}
     port: 443
   caBundle: {{ .WorkAPIServiceCABundle }}
   groupPriorityMinimum: 10000

--- a/manifests/cluster-manager/cluster-manager-work-webhook-clusterrolebinding.yaml
+++ b/manifests/cluster-manager/cluster-manager-work-webhook-clusterrolebinding.yaml
@@ -9,4 +9,4 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ .ClusterManagerName }}-work-webhook-sa
-    namespace: open-cluster-management-hub
+    namespace: {{ .ClusterManagerNamespace }}

--- a/manifests/cluster-manager/cluster-manager-work-webhook-deployment.yaml
+++ b/manifests/cluster-manager/cluster-manager-work-webhook-deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .ClusterManagerName }}-work-webhook
-  namespace: open-cluster-management-hub
+  namespace: {{ .ClusterManagerNamespace }}
   labels:
     app: {{ .ClusterManagerName }}-work-webhook
 spec:

--- a/manifests/cluster-manager/cluster-manager-work-webhook-service.yaml
+++ b/manifests/cluster-manager/cluster-manager-work-webhook-service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: cluster-manager-work-webhook
-  namespace: open-cluster-management-hub
+  namespace: {{ .ClusterManagerNamespace }}
 spec:
   selector:
     app: {{ .ClusterManagerName }}-work-webhook

--- a/manifests/cluster-manager/cluster-manager-work-webhook-serviceaccount.yaml
+++ b/manifests/cluster-manager/cluster-manager-work-webhook-serviceaccount.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ .ClusterManagerName }}-work-webhook-sa
-  namespace: open-cluster-management-hub
+  namespace: {{ .ClusterManagerNamespace }} 

--- a/manifests/config.go
+++ b/manifests/config.go
@@ -1,0 +1,12 @@
+package manifests
+
+type HubConfig struct {
+	ClusterManagerName             string
+	ClusterManagerNamespace        string
+	RegistrationImage              string
+	RegistrationAPIServiceCABundle string
+	WorkImage                      string
+	WorkAPIServiceCABundle         string
+	PlacementImage                 string
+	Replica                        int32
+}

--- a/pkg/helpers/helpers.go
+++ b/pkg/helpers/helpers.go
@@ -581,7 +581,6 @@ func SetRelatedResourcesStatusesWithObj(
 		return
 	}
 	SetRelatedResourcesStatuses(relatedResourcesStatuses, res)
-	return
 }
 
 func UpdateClusterManagerRelatedResourcesFn(relatedResources ...operatorapiv1.RelatedResourceMeta) UpdateClusterManagerStatusFunc {

--- a/pkg/helpers/helpers_test.go
+++ b/pkg/helpers/helpers_test.go
@@ -716,13 +716,13 @@ func TestApplyDeployment(t *testing.T) {
 		{
 			name:                "Apply a deployment without nodePlacement",
 			deploymentName:      "cluster-manager-registration-controller",
-			deploymentNamespace: "open-cluster-management-hub",
+			deploymentNamespace: ClusterManagerDefaultNamespace,
 			expectErr:           false,
 		},
 		{
 			name:                "Apply a deployment with nodePlacement",
 			deploymentName:      "cluster-manager-registration-controller",
-			deploymentNamespace: "open-cluster-management-hub",
+			deploymentNamespace: ClusterManagerDefaultNamespace,
 			nodePlacement: operatorapiv1.NodePlacement{
 				NodeSelector: map[string]string{"node-role.kubernetes.io/infra": ""},
 				Tolerations: []corev1.Toleration{
@@ -767,29 +767,21 @@ func TestApplyDeployment(t *testing.T) {
 	}
 }
 
-type config struct {
-	ClusterManagerName             string
-	RegistrationImage              string
-	RegistrationAPIServiceCABundle string
-	WorkImage                      string
-	WorkAPIServiceCABundle         string
-	PlacementImage                 string
-	Replica                        int32
-}
-
 func TestGetRelatedResource(t *testing.T) {
 	cases := []struct {
 		name                    string
 		manifestFile            string
-		config                  config
+		config                  manifests.HubConfig
 		expectedErr             error
 		expectedRelatedResource operatorapiv1.RelatedResourceMeta
 	}{
 		{
 			name:         "get correct crd relatedResources",
 			manifestFile: "cluster-manager/0000_00_addon.open-cluster-management.io_clustermanagementaddons.crd.yaml",
-
-			config:      config{ClusterManagerName: "test", Replica: 1},
+			config: manifests.HubConfig{
+				ClusterManagerName: "test",
+				Replica:            1,
+			},
 			expectedErr: nil,
 			expectedRelatedResource: operatorapiv1.RelatedResourceMeta{
 				Group:     "apiextensions.k8s.io",
@@ -802,8 +794,11 @@ func TestGetRelatedResource(t *testing.T) {
 		{
 			name:         "get correct clusterrole relatedResources",
 			manifestFile: "cluster-manager/cluster-manager-registration-clusterrole.yaml",
-			config:       config{ClusterManagerName: "test", Replica: 1},
-			expectedErr:  nil,
+			config: manifests.HubConfig{
+				ClusterManagerName: "test",
+				Replica:            1,
+			},
+			expectedErr: nil,
 			expectedRelatedResource: operatorapiv1.RelatedResourceMeta{
 				Group:     "rbac.authorization.k8s.io",
 				Version:   "v1",
@@ -815,13 +810,17 @@ func TestGetRelatedResource(t *testing.T) {
 		{
 			name:         "get correct deployment relatedResources",
 			manifestFile: "cluster-manager/cluster-manager-registration-deployment.yaml",
-			config:       config{ClusterManagerName: "test", Replica: 1},
-			expectedErr:  nil,
+			config: manifests.HubConfig{
+				ClusterManagerName:      "test",
+				ClusterManagerNamespace: "test-namespace",
+				Replica:                 1,
+			},
+			expectedErr: nil,
 			expectedRelatedResource: operatorapiv1.RelatedResourceMeta{
 				Group:     "apps",
 				Version:   "v1",
 				Resource:  "deployments",
-				Namespace: "open-cluster-management-hub",
+				Namespace: "test-namespace",
 				Name:      "test-registration-controller",
 			},
 		},

--- a/pkg/operators/clustermanager/controllers/certrotationcontroller/certrotation_controller.go
+++ b/pkg/operators/clustermanager/controllers/certrotationcontroller/certrotation_controller.go
@@ -8,15 +8,19 @@ import (
 	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/operator/events"
 	errorhelpers "github.com/openshift/library-go/pkg/operator/v1helpers"
+	operatorhelpers "github.com/openshift/library-go/pkg/operator/v1helpers"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
 	corev1informers "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
 
 	operatorinformer "open-cluster-management.io/api/client/operator/informers/externalversions/operator/v1"
 	operatorlister "open-cluster-management.io/api/client/operator/listers/operator/v1"
+	operatorv1 "open-cluster-management.io/api/operator/v1"
 	"open-cluster-management.io/registration-operator/pkg/certrotation"
 	"open-cluster-management.io/registration-operator/pkg/helpers"
 )
@@ -44,11 +48,18 @@ var ResyncInterval = time.Minute * 5
 //    It creates the next one when a given percentage of the validity of the previous cert has
 //    passed, or when a new CA has been created.
 type certRotationController struct {
-	signingRotation      certrotation.SigningRotation
-	caBundleRotation     certrotation.CABundleRotation
-	targetRotations      []certrotation.TargetRotation
+	rotationMap          map[string]rotations // key is clusterManager's name, value is a rotations struct
 	kubeClient           kubernetes.Interface
+	secretInformer       corev1informers.SecretInformer
+	configMapInformer    corev1informers.ConfigMapInformer
+	recorder             events.Recorder
 	clusterManagerLister operatorlister.ClusterManagerLister
+}
+
+type rotations struct {
+	signingRotation  certrotation.SigningRotation
+	caBundleRotation certrotation.CABundleRotation
+	targetRotations  []certrotation.TargetRotation
 }
 
 func NewCertRotationController(
@@ -58,105 +69,198 @@ func NewCertRotationController(
 	clusterManagerInformer operatorinformer.ClusterManagerInformer,
 	recorder events.Recorder,
 ) factory.Controller {
-	signingRotation := certrotation.SigningRotation{
-		Namespace:        helpers.ClusterManagerNamespace,
-		Name:             signerSecret,
-		SignerNamePrefix: signerNamePrefix,
-		Validity:         SigningCertValidity,
-		Lister:           secretInformer.Lister(),
-		Client:           kubeClient.CoreV1(),
-		EventRecorder:    recorder,
-	}
-	caBundleRotation := certrotation.CABundleRotation{
-		Namespace:     helpers.ClusterManagerNamespace,
-		Name:          caBundleConfigmap,
-		Lister:        configMapInformer.Lister(),
-		Client:        kubeClient.CoreV1(),
-		EventRecorder: recorder,
-	}
-	targetRotations := []certrotation.TargetRotation{
-		{
-			Namespace:     helpers.ClusterManagerNamespace,
-			Name:          helpers.RegistrationWebhookSecret,
-			Validity:      TargetCertValidity,
-			HostNames:     []string{fmt.Sprintf("%s.%s.svc", helpers.RegistrationWebhookService, helpers.ClusterManagerNamespace)},
-			Lister:        secretInformer.Lister(),
-			Client:        kubeClient.CoreV1(),
-			EventRecorder: recorder,
-		},
-		{
-			Namespace:     helpers.ClusterManagerNamespace,
-			Name:          helpers.WorkWebhookSecret,
-			Validity:      TargetCertValidity,
-			HostNames:     []string{fmt.Sprintf("%s.%s.svc", helpers.WorkWebhookService, helpers.ClusterManagerNamespace)},
-			Lister:        secretInformer.Lister(),
-			Client:        kubeClient.CoreV1(),
-			EventRecorder: recorder,
-		},
-	}
-
 	c := &certRotationController{
-		signingRotation:      signingRotation,
-		caBundleRotation:     caBundleRotation,
-		targetRotations:      targetRotations,
+		rotationMap:          make(map[string]rotations),
 		kubeClient:           kubeClient,
+		secretInformer:       secretInformer,
+		configMapInformer:    configMapInformer,
+		recorder:             recorder,
 		clusterManagerLister: clusterManagerInformer.Lister(),
 	}
 	return factory.New().
 		ResyncEvery(ResyncInterval).
 		WithSync(c.sync).
-		WithInformers(
-			secretInformer.Informer(),
-			configMapInformer.Informer(),
-			clusterManagerInformer.Informer(),
-		).
+		WithFilteredEventsInformersQueueKeyFunc(
+			helpers.ClusterManagerConfigmapQueueKeyFunc(c.clusterManagerLister),
+			func(obj interface{}) bool {
+				accessor, _ := meta.Accessor(obj)
+				if name := accessor.GetName(); name != caBundleConfigmap {
+					return false
+				}
+				return true
+			},
+			configMapInformer.Informer()).
+		WithFilteredEventsInformersQueueKeyFunc(
+			helpers.ClusterManagerSecretQueueKeyFunc(c.clusterManagerLister),
+			func(obj interface{}) bool {
+				accessor, _ := meta.Accessor(obj)
+				if name := accessor.GetName(); name != signerSecret && name != helpers.RegistrationWebhookSecret && name != helpers.WorkWebhookSecret {
+					return false
+				}
+				return true
+			},
+			secretInformer.Informer()).
+		WithInformersQueueKeyFunc(func(obj runtime.Object) string {
+			accessor, _ := meta.Accessor(obj)
+			return accessor.GetName()
+		}, clusterManagerInformer.Informer()).
 		ToController("CertRotationController", recorder)
 }
 
 func (c certRotationController) sync(ctx context.Context, syncCtx factory.SyncContext) error {
-	// do nothing if there is no cluster manager
-	clustermanagers, err := c.clusterManagerLister.List(labels.Everything())
-	if err != nil {
-		return err
+	key := syncCtx.QueueKey()
+	switch {
+	case key == "":
+		return nil
+	case key == factory.DefaultQueueKey:
+		// ensure every clustermanager's certificates
+		clustermanagers, err := c.clusterManagerLister.List(labels.Everything())
+		if err != nil {
+			return err
+		}
+
+		// do nothing if there is no cluster manager
+		if len(clustermanagers) == 0 {
+			klog.V(4).Infof("No ClusterManager found")
+			return nil
+		}
+
+		errs := []error{}
+		for i := range clustermanagers {
+			err = c.syncOne(ctx, syncCtx, clustermanagers[i])
+			if err != nil {
+				errs = append(errs, err)
+			}
+		}
+		return operatorhelpers.NewMultiLineAggregate(errs)
+	default:
+		clustermanagerName := key
+		clustermanager, err := c.clusterManagerLister.Get(clustermanagerName)
+		// ClusterManager not found, could have been deleted, do nothing.
+		if errors.IsNotFound(err) {
+			return fmt.Errorf("no clustermanager for %s", clustermanagerName)
+		}
+		err = c.syncOne(ctx, syncCtx, clustermanager)
+		if err != nil {
+			return err
+		}
+		return nil
 	}
-	if len(clustermanagers) == 0 {
-		klog.V(4).Infof("No ClusterManager found")
+}
+
+func (c certRotationController) syncOne(ctx context.Context, syncCtx factory.SyncContext, clustermanager *operatorv1.ClusterManager) error {
+	clustermanagerName := clustermanager.Name
+	clustermanagerNamespace := helpers.ClusterManagerNamespace(clustermanager.Name, clustermanager.Spec.DeployOption.Mode)
+
+	var err error
+
+	klog.Infof("Reconciling ClusterManager %q", clustermanagerName)
+	// if the cluster manager is deleting, delete the rotation in map as well.
+	if !clustermanager.DeletionTimestamp.IsZero() {
+		// clean up all resources related with this clustermanager
+		if _, ok := c.rotationMap[clustermanagerName]; ok {
+			// delete signerSecret
+			err = c.kubeClient.CoreV1().Secrets(clustermanagerNamespace).Delete(ctx, signerSecret, metav1.DeleteOptions{})
+			if err != nil {
+				return fmt.Errorf("clean up deleted cluster-manager, deleting signer secret failed, err:%s", err.Error())
+			}
+
+			// delete caBundleConfig
+			err = c.kubeClient.CoreV1().ConfigMaps(clustermanagerNamespace).Delete(ctx, caBundleConfigmap, metav1.DeleteOptions{})
+			if err != nil {
+				return fmt.Errorf("clean up deleted cluster-manager, deleting caBundle config failed, err:%s", err.Error())
+			}
+
+			// delete registration webhook secret
+			err = c.kubeClient.CoreV1().Secrets(clustermanagerNamespace).Delete(ctx, helpers.RegistrationWebhookSecret, metav1.DeleteOptions{})
+			if err != nil {
+				return fmt.Errorf("clean up deleted cluster-manager, deleting registration webhook secret failed, err:%s", err.Error())
+			}
+
+			// delete work webhook secret
+			err = c.kubeClient.CoreV1().Secrets(clustermanagerNamespace).Delete(ctx, helpers.WorkWebhookSecret, metav1.DeleteOptions{})
+			if err != nil {
+				return fmt.Errorf("clean up deleted cluster-manager, deleting work webhook secret failed, err:%s", err.Error())
+			}
+
+			delete(c.rotationMap, clustermanagerName)
+		}
 		return nil
 	}
 
-	klog.Infof("Reconciling ClusterManager %q", clustermanagers[0].Name)
-	// do nothing if the cluster manager is deleting
-	if !clustermanagers[0].DeletionTimestamp.IsZero() {
-		return nil
-	}
-
-	// check if namespace exists or not
-	_, err = c.kubeClient.CoreV1().Namespaces().Get(ctx, helpers.ClusterManagerNamespace, metav1.GetOptions{})
+	_, err = c.kubeClient.CoreV1().Namespaces().Get(ctx, clustermanagerNamespace, metav1.GetOptions{})
 	if errors.IsNotFound(err) {
-		return fmt.Errorf("namespace %q does not exist yet", helpers.ClusterManagerNamespace)
+		return fmt.Errorf("namespace %q does not exist yet", clustermanagerNamespace)
 	}
 	if err != nil {
 		return err
 	}
 
-	// reconcile cert/key pair for signer
-	signingCertKeyPair, err := c.signingRotation.EnsureSigningCertKeyPair()
+	// check if rotations exist, if not exist then create one
+	if _, ok := c.rotationMap[clustermanager.Name]; !ok {
+		signingRotation := certrotation.SigningRotation{
+			Namespace:        clustermanagerNamespace,
+			Name:             signerSecret,
+			SignerNamePrefix: signerNamePrefix,
+			Validity:         SigningCertValidity,
+			Lister:           c.secretInformer.Lister(),
+			Client:           c.kubeClient.CoreV1(),
+			EventRecorder:    c.recorder,
+		}
+		caBundleRotation := certrotation.CABundleRotation{
+			Namespace:     clustermanagerNamespace,
+			Name:          caBundleConfigmap,
+			Lister:        c.configMapInformer.Lister(),
+			Client:        c.kubeClient.CoreV1(),
+			EventRecorder: c.recorder,
+		}
+		targetRotations := []certrotation.TargetRotation{
+			{
+				Namespace:     clustermanagerNamespace,
+				Name:          helpers.RegistrationWebhookSecret,
+				Validity:      TargetCertValidity,
+				HostNames:     []string{fmt.Sprintf("%s.%s.svc", helpers.RegistrationWebhookService, clustermanagerNamespace)},
+				Lister:        c.secretInformer.Lister(),
+				Client:        c.kubeClient.CoreV1(),
+				EventRecorder: c.recorder,
+			},
+			{
+				Namespace:     clustermanagerNamespace,
+				Name:          helpers.WorkWebhookSecret,
+				Validity:      TargetCertValidity,
+				HostNames:     []string{fmt.Sprintf("%s.%s.svc", helpers.WorkWebhookService, clustermanagerNamespace)},
+				Lister:        c.secretInformer.Lister(),
+				Client:        c.kubeClient.CoreV1(),
+				EventRecorder: c.recorder,
+			},
+		}
+		c.rotationMap[clustermanagerName] = rotations{
+			signingRotation:  signingRotation,
+			caBundleRotation: caBundleRotation,
+			targetRotations:  targetRotations,
+		}
+	}
+
+	// Ensure certificates are exists
+	rotations := c.rotationMap[clustermanagerName] // reconcile cert/key pair for signer
+	signingCertKeyPair, err := rotations.signingRotation.EnsureSigningCertKeyPair()
 	if err != nil {
 		return err
 	}
 
 	// reconcile ca bundle
-	cabundleCerts, err := c.caBundleRotation.EnsureConfigMapCABundle(signingCertKeyPair)
+	cabundleCerts, err := rotations.caBundleRotation.EnsureConfigMapCABundle(signingCertKeyPair)
 	if err != nil {
 		return err
 	}
 
 	// reconcile target cert/key pairs
 	errs := []error{}
-	for _, targetRotation := range c.targetRotations {
+	for _, targetRotation := range rotations.targetRotations {
 		if err := targetRotation.EnsureTargetCertKeyPair(signingCertKeyPair, cabundleCerts); err != nil {
 			errs = append(errs, err)
 		}
 	}
+
 	return errorhelpers.NewMultiLineAggregate(errs)
 }

--- a/pkg/operators/clustermanager/controllers/clustermanagercontroller/clustermanager_controller.go
+++ b/pkg/operators/clustermanager/controllers/clustermanagercontroller/clustermanager_controller.go
@@ -36,6 +36,7 @@ var (
 		"manifestworks.work.open-cluster-management.io",
 		"managedclusters.cluster.open-cluster-management.io",
 	}
+
 	staticResourceFiles = []string{
 		"cluster-manager/0000_00_addon.open-cluster-management.io_clustermanagementaddons.crd.yaml",
 		"cluster-manager/0000_00_clusters.open-cluster-management.io_managedclusters.crd.yaml",
@@ -53,7 +54,6 @@ var (
 		"cluster-manager/cluster-manager-registration-webhook-clusterrolebinding.yaml",
 		"cluster-manager/cluster-manager-registration-webhook-service.yaml",
 		"cluster-manager/cluster-manager-registration-webhook-serviceaccount.yaml",
-		"cluster-manager/cluster-manager-registration-webhook-apiservice.yaml",
 		"cluster-manager/cluster-manager-registration-webhook-clustersetbinding-validatingconfiguration.yaml",
 		"cluster-manager/cluster-manager-registration-webhook-validatingconfiguration.yaml",
 		"cluster-manager/cluster-manager-registration-webhook-mutatingconfiguration.yaml",
@@ -61,11 +61,16 @@ var (
 		"cluster-manager/cluster-manager-work-webhook-clusterrolebinding.yaml",
 		"cluster-manager/cluster-manager-work-webhook-service.yaml",
 		"cluster-manager/cluster-manager-work-webhook-serviceaccount.yaml",
-		"cluster-manager/cluster-manager-work-webhook-apiservice.yaml",
 		"cluster-manager/cluster-manager-work-webhook-validatingconfiguration.yaml",
 		"cluster-manager/cluster-manager-placement-clusterrole.yaml",
 		"cluster-manager/cluster-manager-placement-clusterrolebinding.yaml",
 		"cluster-manager/cluster-manager-placement-serviceaccount.yaml",
+	}
+
+	// apiserviceResoruceFiles requires CABundle in HubConfig
+	apiserviceResoruceFiles = []string{
+		"cluster-manager/cluster-manager-work-webhook-apiservice.yaml",
+		"cluster-manager/cluster-manager-registration-webhook-apiservice.yaml",
 	}
 
 	deploymentFiles = []string{
@@ -120,9 +125,6 @@ func NewClusterManagerController(
 			helpers.ClusterManagerConfigmapQueueKeyFunc(controller.clusterManagerLister),
 			func(obj interface{}) bool {
 				accessor, _ := meta.Accessor(obj)
-				if namespace := accessor.GetNamespace(); namespace != helpers.ClusterManagerNamespace {
-					return false
-				}
 				if name := accessor.GetName(); name != caBundleConfigmap {
 					return false
 				}
@@ -134,17 +136,6 @@ func NewClusterManagerController(
 			return accessor.GetName()
 		}, clusterManagerInformer.Informer()).
 		ToController("ClusterManagerController", recorder)
-}
-
-// hubConfig is used to render the template of hub manifests
-type hubConfig struct {
-	ClusterManagerName             string
-	RegistrationImage              string
-	RegistrationAPIServiceCABundle string
-	WorkImage                      string
-	WorkAPIServiceCABundle         string
-	PlacementImage                 string
-	Replica                        int32
 }
 
 func (n *clusterManagerController) sync(ctx context.Context, controllerContext factory.SyncContext) error {
@@ -160,13 +151,15 @@ func (n *clusterManagerController) sync(ctx context.Context, controllerContext f
 		return err
 	}
 	clusterManager = clusterManager.DeepCopy()
+	clusterManagerNamespace := helpers.ClusterManagerNamespace(clusterManagerName, clusterManager.Spec.DeployOption.Mode)
 
-	config := hubConfig{
-		ClusterManagerName: clusterManager.Name,
-		RegistrationImage:  clusterManager.Spec.RegistrationImagePullSpec,
-		WorkImage:          clusterManager.Spec.WorkImagePullSpec,
-		PlacementImage:     clusterManager.Spec.PlacementImagePullSpec,
-		Replica:            helpers.DetermineReplicaByNodes(ctx, n.kubeClient),
+	config := manifests.HubConfig{
+		ClusterManagerName:      clusterManager.Name,
+		ClusterManagerNamespace: clusterManagerNamespace,
+		RegistrationImage:       clusterManager.Spec.RegistrationImagePullSpec,
+		WorkImage:               clusterManager.Spec.WorkImagePullSpec,
+		PlacementImage:          clusterManager.Spec.PlacementImagePullSpec,
+		Replica:                 helpers.DetermineReplicaByNodes(ctx, n.kubeClient),
 	}
 
 	// Update finalizer at first
@@ -193,25 +186,8 @@ func (n *clusterManagerController) sync(ctx context.Context, controllerContext f
 		return n.removeClusterManagerFinalizer(ctx, clusterManager)
 	}
 
-	// try to load ca bundle from configmap
-	caBundle := "placeholder"
-	configmap, err := n.configMapLister.ConfigMaps(helpers.ClusterManagerNamespace).Get(caBundleConfigmap)
-	switch {
-	case errors.IsNotFound(err):
-		// do nothing
-	case err != nil:
-		return err
-	default:
-		if cb := configmap.Data["ca-bundle.crt"]; len(cb) > 0 {
-			caBundle = cb
-		}
-	}
-	encodedCaBundle := base64.StdEncoding.EncodeToString([]byte(caBundle))
-	config.RegistrationAPIServiceCABundle = encodedCaBundle
-	config.WorkAPIServiceCABundle = encodedCaBundle
-
+	// Apply static files(Which don't require CABundle)
 	var relatedResources []operatorapiv1.RelatedResourceMeta
-	// Apply static files
 	resourceResults := helpers.ApplyDirectly(
 		n.kubeClient,
 		n.apiExtensionClient,
@@ -230,6 +206,48 @@ func (n *clusterManagerController) sync(ctx context.Context, controllerContext f
 	)
 	errs := []error{}
 	for _, result := range resourceResults {
+		if result.Error != nil {
+			errs = append(errs, fmt.Errorf("%q (%T): %v", result.File, result.Type, result.Error))
+		}
+	}
+
+	// try to load ca bundle from configmap
+	// if the namespace not found yet, skip this and apply static resources first
+	caBundle := "placeholder"
+	configmap, err := n.configMapLister.ConfigMaps(clusterManagerNamespace).Get(caBundleConfigmap)
+	switch {
+	case errors.IsNotFound(err):
+		// do nothing
+	case err != nil:
+		return err
+	default:
+		if cb := configmap.Data["ca-bundle.crt"]; len(cb) > 0 {
+			caBundle = cb
+		}
+	}
+
+	encodedCaBundle := base64.StdEncoding.EncodeToString([]byte(caBundle))
+	config.RegistrationAPIServiceCABundle = encodedCaBundle
+	config.WorkAPIServiceCABundle = encodedCaBundle
+
+	// Apply apiservice files
+	apiserviceResults := helpers.ApplyDirectly(
+		n.kubeClient,
+		n.apiExtensionClient,
+		n.apiRegistrationClient,
+		controllerContext.Recorder(),
+		func(name string) ([]byte, error) {
+			template, err := manifests.ClusterManagerManifestFiles.ReadFile(name)
+			if err != nil {
+				return nil, err
+			}
+			objData := assets.MustCreateAssetFromTemplate(name, template, config).Data
+			helpers.SetRelatedResourcesStatusesWithObj(&relatedResources, objData)
+			return objData, nil
+		},
+		apiserviceResoruceFiles...,
+	)
+	for _, result := range apiserviceResults {
 		if result.Error != nil {
 			errs = append(errs, fmt.Errorf("%q (%T): %v", result.File, result.Type, result.Error))
 		}
@@ -338,7 +356,7 @@ func (n *clusterManagerController) removeCRD(ctx context.Context, name string) e
 }
 
 func (n *clusterManagerController) cleanUp(
-	ctx context.Context, controllerContext factory.SyncContext, config hubConfig) error {
+	ctx context.Context, controllerContext factory.SyncContext, config manifests.HubConfig) error {
 	// Remove crd
 	for _, name := range crdNames {
 		err := n.removeCRD(ctx, name)
@@ -348,8 +366,9 @@ func (n *clusterManagerController) cleanUp(
 		controllerContext.Recorder().Eventf("CRDDeleted", "crd %s is deleted", name)
 	}
 
-	// Remove Static files
-	for _, file := range staticResourceFiles {
+	// Remove All Static files
+	allResourceFiles := append(staticResourceFiles, apiserviceResoruceFiles...)
+	for _, file := range allResourceFiles {
 		err := helpers.CleanUpStaticObject(
 			ctx,
 			n.kubeClient,
@@ -368,5 +387,6 @@ func (n *clusterManagerController) cleanUp(
 			return err
 		}
 	}
+
 	return nil
 }

--- a/pkg/operators/manager.go
+++ b/pkg/operators/manager.go
@@ -17,7 +17,6 @@ import (
 	operatorclient "open-cluster-management.io/api/client/operator/clientset/versioned"
 	operatorinformer "open-cluster-management.io/api/client/operator/informers/externalversions"
 	workclientset "open-cluster-management.io/api/client/work/clientset/versioned"
-	"open-cluster-management.io/registration-operator/pkg/helpers"
 	certrotationcontroller "open-cluster-management.io/registration-operator/pkg/operators/clustermanager/controllers/certrotationcontroller"
 	"open-cluster-management.io/registration-operator/pkg/operators/clustermanager/controllers/clustermanagercontroller"
 	"open-cluster-management.io/registration-operator/pkg/operators/clustermanager/controllers/migrationcontroller"
@@ -51,7 +50,11 @@ func RunClusterManagerOperator(ctx context.Context, controllerContext *controlle
 		return err
 	}
 
-	kubeInformer := informers.NewSharedInformerFactoryWithOptions(kubeClient, 5*time.Minute, informers.WithNamespace(helpers.ClusterManagerNamespace))
+	// kubeInformer is for 3 usages: configmapInformer, secretInformer, deploynmentInformer
+	// After we introduced detached mode, the hub components could be installed in a customized namespace.(Before that, it only inform from "open-cluster-management-hub" namespace)
+	// It requires us to add filter for each Informer respectively.
+	// TODO: Wathc all namespace may cause performance issue.
+	kubeInformer := informers.NewSharedInformerFactoryWithOptions(kubeClient, 5*time.Minute)
 
 	// Build operator client and informer
 	operatorClient, err := operatorclient.NewForConfig(controllerContext.KubeConfig)

--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -63,7 +63,7 @@ func NewTester(kubeconfigPath string) (*Tester, error) {
 	var tester = Tester{
 		EventuallyTimeout:                60 * time.Second, // seconds
 		EventuallyInterval:               1 * time.Second,  // seconds
-		clusterManagerNamespace:          helpers.ClusterManagerNamespace,
+		clusterManagerNamespace:          helpers.ClusterManagerDefaultNamespace,
 		klusterletDefaultNamespace:       helpers.KlusterletDefaultNamespace,
 		hubRegistrationDeployment:        "cluster-manager-registration-controller",
 		hubRegistrationWebhookDeployment: "cluster-manager-registration-webhook",

--- a/test/integration/clustermanager_test.go
+++ b/test/integration/clustermanager_test.go
@@ -12,6 +12,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/util/cert"
 
 	"github.com/openshift/library-go/pkg/controller/controllercmd"
@@ -22,26 +23,34 @@ import (
 	"open-cluster-management.io/registration-operator/test/integration/util"
 )
 
-func startHubOperator(ctx context.Context) {
+func startHubOperator(ctx context.Context, mode v1.InstallMode) {
 	certrotation.SigningCertValidity = time.Second * 30
 	certrotation.TargetCertValidity = time.Second * 10
 	certrotation.ResyncInterval = time.Second * 1
 
+	var config *rest.Config
+	switch mode {
+	case v1.InstallModeDefault:
+		config = restConfig
+	case v1.InstallModeDetached:
+		config = detachedRestConfig
+	}
+
 	err := operators.RunClusterManagerOperator(ctx, &controllercmd.ControllerContext{
-		KubeConfig:    restConfig,
+		KubeConfig:    config,
 		EventRecorder: util.NewIntegrationTestEventRecorder("integration"),
 	})
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 }
 
-var _ = ginkgo.Describe("ClusterManager", func() {
+var _ = ginkgo.Describe("ClusterManager Default Mode", func() {
 	var cancel context.CancelFunc
 	var hubRegistrationDeployment = fmt.Sprintf("%s-registration-controller", clusterManagerName)
 
 	ginkgo.BeforeEach(func() {
 		var ctx context.Context
 		ctx, cancel = context.WithCancel(context.Background())
-		go startHubOperator(ctx)
+		go startHubOperator(ctx, v1.InstallModeDefault)
 	})
 
 	ginkgo.AfterEach(func() {
@@ -53,182 +62,190 @@ var _ = ginkgo.Describe("ClusterManager", func() {
 	ginkgo.Context("Deploy and clean hub component", func() {
 		ginkgo.It("should have expected resource created successfully", func() {
 			// Check namespace
-			gomega.Eventually(func() bool {
+			gomega.Eventually(func() error {
 				if _, err := kubeClient.CoreV1().Namespaces().Get(context.Background(), hubNamespace, metav1.GetOptions{}); err != nil {
-					return false
+					return err
 				}
-				return true
-			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeTrue())
+				return nil
+			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeNil())
 
 			// Check clusterrole/clusterrolebinding
 			hubRegistrationClusterRole := fmt.Sprintf("open-cluster-management:%s-registration:controller", clusterManagerName)
 			hubRegistrationWebhookClusterRole := fmt.Sprintf("open-cluster-management:%s-registration:webhook", clusterManagerName)
 			hubWorkWebhookClusterRole := fmt.Sprintf("open-cluster-management:%s-registration:webhook", clusterManagerName)
-			gomega.Eventually(func() bool {
+			gomega.Eventually(func() error {
 				if _, err := kubeClient.RbacV1().ClusterRoles().Get(context.Background(), hubRegistrationClusterRole, metav1.GetOptions{}); err != nil {
-					return false
+					return err
 				}
-				return true
-			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeTrue())
-			gomega.Eventually(func() bool {
+				return nil
+			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeNil())
+			gomega.Eventually(func() error {
 				if _, err := kubeClient.RbacV1().ClusterRoles().Get(context.Background(), hubRegistrationWebhookClusterRole, metav1.GetOptions{}); err != nil {
-					return false
+					return err
 				}
-				return true
-			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeTrue())
-			gomega.Eventually(func() bool {
+				return nil
+			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeNil())
+			gomega.Eventually(func() error {
 				if _, err := kubeClient.RbacV1().ClusterRoles().Get(context.Background(), hubWorkWebhookClusterRole, metav1.GetOptions{}); err != nil {
-					return false
+					return err
 				}
-				return true
-			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeTrue())
-			gomega.Eventually(func() bool {
+				return nil
+			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeNil())
+			gomega.Eventually(func() error {
 				if _, err := kubeClient.RbacV1().ClusterRoleBindings().Get(context.Background(), hubRegistrationClusterRole, metav1.GetOptions{}); err != nil {
-					return false
+					return err
 				}
-				return true
-			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeTrue())
-			gomega.Eventually(func() bool {
+				return nil
+			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeNil())
+			gomega.Eventually(func() error {
 				if _, err := kubeClient.RbacV1().ClusterRoleBindings().Get(context.Background(), hubRegistrationWebhookClusterRole, metav1.GetOptions{}); err != nil {
-					return false
+					return err
 				}
-				return true
-			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeTrue())
-			gomega.Eventually(func() bool {
+				return nil
+			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeNil())
+			gomega.Eventually(func() error {
 				if _, err := kubeClient.RbacV1().ClusterRoleBindings().Get(context.Background(), hubWorkWebhookClusterRole, metav1.GetOptions{}); err != nil {
-					return false
+					return err
 				}
-				return true
-			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeTrue())
+				return nil
+			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeNil())
 
 			// Check service account
 			hubRegistrationSA := fmt.Sprintf("%s-registration-controller-sa", clusterManagerName)
 			hubRegistrationWebhookSA := fmt.Sprintf("%s-registration-webhook-sa", clusterManagerName)
 			hubWorkWebhookSA := fmt.Sprintf("%s-work-webhook-sa", clusterManagerName)
-			gomega.Eventually(func() bool {
+			gomega.Eventually(func() error {
 				if _, err := kubeClient.CoreV1().ServiceAccounts(hubNamespace).Get(context.Background(), hubRegistrationSA, metav1.GetOptions{}); err != nil {
-					return false
+					return err
 				}
-				return true
-			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeTrue())
-			gomega.Eventually(func() bool {
+				return nil
+			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeNil())
+			gomega.Eventually(func() error {
 				if _, err := kubeClient.CoreV1().ServiceAccounts(hubNamespace).Get(context.Background(), hubRegistrationWebhookSA, metav1.GetOptions{}); err != nil {
-					return false
+					return err
 				}
-				return true
-			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeTrue())
-			gomega.Eventually(func() bool {
+				return nil
+			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeNil())
+			gomega.Eventually(func() error {
 				if _, err := kubeClient.CoreV1().ServiceAccounts(hubNamespace).Get(context.Background(), hubWorkWebhookSA, metav1.GetOptions{}); err != nil {
-					return false
+					return err
 				}
-				return true
-			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeTrue())
+				return nil
+			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeNil())
 
 			// Check deployment
-			gomega.Eventually(func() bool {
+			gomega.Eventually(func() error {
 				if _, err := kubeClient.AppsV1().Deployments(hubNamespace).Get(context.Background(), hubRegistrationDeployment, metav1.GetOptions{}); err != nil {
-					return false
+					return err
 				}
-				return true
-			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeTrue())
+				return nil
+			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeNil())
 
 			hubRegistrationWebhookDeployment := fmt.Sprintf("%s-registration-webhook", clusterManagerName)
-			gomega.Eventually(func() bool {
+			gomega.Eventually(func() error {
 				if _, err := kubeClient.AppsV1().Deployments(hubNamespace).Get(context.Background(), hubRegistrationWebhookDeployment, metav1.GetOptions{}); err != nil {
-					return false
+					return err
 				}
-				return true
-			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeTrue())
+				return nil
+			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeNil())
 
 			hubWorkWebhookDeployment := fmt.Sprintf("%s-work-webhook", clusterManagerName)
-			gomega.Eventually(func() bool {
+			gomega.Eventually(func() error {
 				if _, err := kubeClient.AppsV1().Deployments(hubNamespace).Get(context.Background(), hubWorkWebhookDeployment, metav1.GetOptions{}); err != nil {
-					return false
+					return err
 				}
-				return true
-			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeTrue())
+				return nil
+			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeNil())
 
 			// Check service
-			gomega.Eventually(func() bool {
+			gomega.Eventually(func() error {
 				if _, err := kubeClient.CoreV1().Services(hubNamespace).Get(context.Background(), "cluster-manager-registration-webhook", metav1.GetOptions{}); err != nil {
-					return false
+					return err
 				}
-				return true
-			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeTrue())
+				return nil
+			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeNil())
 
-			gomega.Eventually(func() bool {
+			gomega.Eventually(func() error {
 				if _, err := kubeClient.CoreV1().Services(hubNamespace).Get(context.Background(), "cluster-manager-work-webhook", metav1.GetOptions{}); err != nil {
-					return false
+					return err
 				}
-				return true
-			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeTrue())
+				return nil
+			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeNil())
 
 			// Check webhook secret
 			registrationWebhookSecret := "registration-webhook-serving-cert"
-			gomega.Eventually(func() bool {
+			gomega.Eventually(func() error {
 				s, err := kubeClient.CoreV1().Secrets(hubNamespace).Get(context.Background(), registrationWebhookSecret, metav1.GetOptions{})
 				if err != nil {
-					return false
+					return err
 				}
-				if s.Data == nil || s.Data["tls.crt"] == nil || s.Data["tls.key"] == nil {
-					return false
+				if s.Data == nil {
+					return fmt.Errorf("s.Data is nil")
+				} else if s.Data["tls.crt"] == nil {
+					return fmt.Errorf("s.Data doesn't contain key 'tls.crt'")
+				} else if s.Data["tls.key"] == nil {
+					return fmt.Errorf("s.Data doesn't contain key 'tls.key'")
 				}
-				return true
-			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeTrue())
+				return nil
+			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeNil())
 
 			workWebhookSecret := "work-webhook-serving-cert"
-			gomega.Eventually(func() bool {
+			gomega.Eventually(func() error {
 				s, err := kubeClient.CoreV1().Secrets(hubNamespace).Get(context.Background(), workWebhookSecret, metav1.GetOptions{})
 				if err != nil {
-					return false
+					return err
 				}
-				if s.Data == nil || s.Data["tls.crt"] == nil || s.Data["tls.key"] == nil {
-					return false
+				if s.Data == nil {
+					return fmt.Errorf("s.Data is nil")
+				} else if s.Data["tls.crt"] == nil {
+					return fmt.Errorf("s.Data doesn't contain key 'tls.crt'")
+				} else if s.Data["tls.key"] == nil {
+					return fmt.Errorf("s.Data doesn't contain key 'tls.key'")
 				}
-				return true
-			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeTrue())
+				return nil
+			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeNil())
 
 			// Check validating webhook
 			registrationValidtingWebhook := "managedclustervalidators.admission.cluster.open-cluster-management.io"
-			gomega.Eventually(func() bool {
+			gomega.Eventually(func() error {
 				if _, err := kubeClient.AdmissionregistrationV1().ValidatingWebhookConfigurations().Get(context.Background(), registrationValidtingWebhook, metav1.GetOptions{}); err != nil {
-					return false
+					return err
 				}
-				return true
-			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeTrue())
+				return nil
+			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeNil())
 
 			workValidtingWebhook := "manifestworkvalidators.admission.work.open-cluster-management.io"
-			gomega.Eventually(func() bool {
+			gomega.Eventually(func() error {
 				if _, err := kubeClient.AdmissionregistrationV1().ValidatingWebhookConfigurations().Get(context.Background(), workValidtingWebhook, metav1.GetOptions{}); err != nil {
-					return false
+					return err
 				}
-				return true
-			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeTrue())
+				return nil
+			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeNil())
 
 			util.AssertClusterManagerCondition(clusterManagerName, operatorClient, "Applied", "ClusterManagerApplied", metav1.ConditionTrue)
 		})
 
 		ginkgo.It("Deployment should be updated when clustermanager is changed", func() {
-			gomega.Eventually(func() bool {
+			gomega.Eventually(func() error {
 				if _, err := kubeClient.AppsV1().Deployments(hubNamespace).Get(context.Background(), hubRegistrationDeployment, metav1.GetOptions{}); err != nil {
-					return false
+					return err
 				}
-				return true
-			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeTrue())
+				return nil
+			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeNil())
 
 			// Check if generations are correct
-			gomega.Eventually(func() bool {
+			gomega.Eventually(func() error {
 				actual, err := operatorClient.OperatorV1().ClusterManagers().Get(context.Background(), clusterManagerName, metav1.GetOptions{})
 				if err != nil {
-					return false
+					return err
 				}
 
 				if actual.Generation != actual.Status.ObservedGeneration {
-					return false
+					return fmt.Errorf("except generation to be %d, but got %d", actual.Status.ObservedGeneration, actual.Generation)
 				}
 
-				return true
-			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeTrue())
+				return nil
+			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeNil())
 
 			clusterManager, err := operatorClient.OperatorV1().ClusterManagers().Get(context.Background(), clusterManagerName, metav1.GetOptions{})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -236,31 +253,31 @@ var _ = ginkgo.Describe("ClusterManager", func() {
 			_, err = operatorClient.OperatorV1().ClusterManagers().Update(context.Background(), clusterManager, metav1.UpdateOptions{})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-			gomega.Eventually(func() bool {
+			gomega.Eventually(func() error {
 				actual, err := kubeClient.AppsV1().Deployments(hubNamespace).Get(context.Background(), hubRegistrationDeployment, metav1.GetOptions{})
 				if err != nil {
-					return false
+					return err
 				}
 				gomega.Expect(len(actual.Spec.Template.Spec.Containers)).Should(gomega.Equal(1))
 				if actual.Spec.Template.Spec.Containers[0].Image != "testimage:latest" {
-					return false
+					return fmt.Errorf("expected image to be testimage:latest but get %s", actual.Spec.Template.Spec.Containers[0].Image)
 				}
-				return true
-			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeTrue())
+				return nil
+			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeNil())
 
 			// Check if generations are correct
-			gomega.Eventually(func() bool {
+			gomega.Eventually(func() error {
 				actual, err := operatorClient.OperatorV1().ClusterManagers().Get(context.Background(), clusterManagerName, metav1.GetOptions{})
 				if err != nil {
-					return false
+					return err
 				}
 
 				if actual.Generation != actual.Status.ObservedGeneration {
-					return false
+					return fmt.Errorf("except generation to be %d, but got %d", actual.Status.ObservedGeneration, actual.Generation)
 				}
 
-				return true
-			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeTrue())
+				return nil
+			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeNil())
 
 			// Check if relatedResources are correct
 			gomega.Eventually(func() error {
@@ -292,83 +309,83 @@ var _ = ginkgo.Describe("ClusterManager", func() {
 			_, err = operatorClient.OperatorV1().ClusterManagers().Update(context.Background(), clusterManager, metav1.UpdateOptions{})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-			gomega.Eventually(func() bool {
+			gomega.Eventually(func() error {
 				actual, err := kubeClient.AppsV1().Deployments(hubNamespace).Get(context.Background(), hubRegistrationDeployment, metav1.GetOptions{})
 				if err != nil {
-					return false
+					return err
 				}
 				gomega.Expect(len(actual.Spec.Template.Spec.Containers)).Should(gomega.Equal(1))
 				if len(actual.Spec.Template.Spec.NodeSelector) == 0 {
-					return false
+					return fmt.Errorf("length of node selector should not equals to 0")
 				}
 				if _, ok := actual.Spec.Template.Spec.NodeSelector["node-role.kubernetes.io/infra"]; !ok {
-					return false
+					return fmt.Errorf("node-role.kubernetes.io/infra not exist")
 				}
 				if len(actual.Spec.Template.Spec.Tolerations) == 0 {
-					return false
+					return fmt.Errorf("length of node selecor should not equals to 0")
 				}
 				for _, toleration := range actual.Spec.Template.Spec.Tolerations {
 					if toleration.Key == "node-role.kubernetes.io/infra" {
-						return true
+						return nil
 					}
 				}
 
-				return false
-			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeTrue())
+				return fmt.Errorf("no key equals to node-role.kubernetes.io/infra")
+			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeNil())
 		})
 		ginkgo.It("Deployment should be reconciled when manually updated", func() {
-			gomega.Eventually(func() bool {
+			gomega.Eventually(func() error {
 				if _, err := kubeClient.AppsV1().Deployments(hubNamespace).Get(context.Background(), hubRegistrationDeployment, metav1.GetOptions{}); err != nil {
-					return false
+					return err
 				}
-				return true
-			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeTrue())
+				return nil
+			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeNil())
 			registrationoDeployment, err := kubeClient.AppsV1().Deployments(hubNamespace).Get(context.Background(), hubRegistrationDeployment, metav1.GetOptions{})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			registrationoDeployment.Spec.Template.Spec.Containers[0].Image = "testimage2:latest"
 			_, err = kubeClient.AppsV1().Deployments(hubNamespace).Update(context.Background(), registrationoDeployment, metav1.UpdateOptions{})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			gomega.Eventually(func() bool {
+			gomega.Eventually(func() error {
 				registrationoDeployment, err := kubeClient.AppsV1().Deployments(hubNamespace).Get(context.Background(), hubRegistrationDeployment, metav1.GetOptions{})
 				if err != nil {
-					return false
+					return appsv1.ErrInvalidLengthGenerated
 				}
 				if registrationoDeployment.Spec.Template.Spec.Containers[0].Image != "testimage:latest" {
-					return false
+					return fmt.Errorf("image should be testimage:latest, but get %s", registrationoDeployment.Spec.Template.Spec.Containers[0].Image)
 				}
-				return true
-			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeTrue())
+				return nil
+			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeNil())
 
 			// Check if generations are correct
-			gomega.Eventually(func() bool {
+			gomega.Eventually(func() error {
 				actual, err := operatorClient.OperatorV1().ClusterManagers().Get(context.Background(), clusterManagerName, metav1.GetOptions{})
 				if err != nil {
-					return false
+					return err
 				}
 
 				registrationDeployment, err := kubeClient.AppsV1().Deployments(hubNamespace).Get(context.Background(), hubRegistrationDeployment, metav1.GetOptions{})
 				if err != nil {
-					return false
+					return err
 				}
 
 				deploymentGeneration := helpers.NewGenerationStatus(appsv1.SchemeGroupVersion.WithResource("deployments"), registrationDeployment)
 				actualGeneration := helpers.FindGenerationStatus(actual.Status.Generations, deploymentGeneration)
 				if deploymentGeneration.LastGeneration != actualGeneration.LastGeneration {
-					return false
+					return fmt.Errorf("expected LastGeneration shoud be %d, but get %d", actualGeneration.LastGeneration, deploymentGeneration.LastGeneration)
 				}
-				return true
-			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeTrue())
+				return nil
+			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeNil())
 		})
 	})
 
 	ginkgo.Context("Cluster manager statuses", func() {
 		ginkgo.It("should have correct degraded conditions", func() {
-			gomega.Eventually(func() bool {
+			gomega.Eventually(func() error {
 				if _, err := kubeClient.AppsV1().Deployments(hubNamespace).Get(context.Background(), hubRegistrationDeployment, metav1.GetOptions{}); err != nil {
-					return false
+					return err
 				}
-				return true
-			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeTrue())
+				return nil
+			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeNil())
 
 			// The cluster manager should be unavailable at first
 			util.AssertClusterManagerCondition(clusterManagerName, operatorClient, "HubRegistrationDegraded", "UnavailableRegistrationPod", metav1.ConditionTrue)
@@ -391,45 +408,45 @@ var _ = ginkgo.Describe("ClusterManager", func() {
 		ginkgo.It("should rotate both serving cert and signing cert before they become expired", func() {
 			secretNames := []string{"signer-secret", "registration-webhook-serving-cert", "work-webhook-serving-cert"}
 			// wait until all secrets and configmap are in place
-			gomega.Eventually(func() bool {
+			gomega.Eventually(func() error {
 				for _, name := range secretNames {
 					if _, err := kubeClient.CoreV1().Secrets(hubNamespace).Get(context.Background(), name, metav1.GetOptions{}); err != nil {
-						return false
+						return err
 					}
 				}
 				if _, err := kubeClient.CoreV1().ConfigMaps(hubNamespace).Get(context.Background(), "ca-bundle-configmap", metav1.GetOptions{}); err != nil {
-					return false
+					return err
 				}
-				return true
-			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeTrue())
+				return nil
+			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeNil())
 
 			// both serving cert and signing cert should aways be valid
-			gomega.Consistently(func() bool {
+			gomega.Consistently(func() error {
 				configmap, err := kubeClient.CoreV1().ConfigMaps(hubNamespace).Get(context.Background(), "ca-bundle-configmap", metav1.GetOptions{})
 				if err != nil {
-					return false
+					return err
 				}
 				for _, name := range []string{"signer-secret", "registration-webhook-serving-cert", "work-webhook-serving-cert"} {
 					secret, err := kubeClient.CoreV1().Secrets(hubNamespace).Get(context.Background(), name, metav1.GetOptions{})
 					if err != nil {
-						return false
+						return err
 					}
 
 					certificates, err := cert.ParseCertsPEM(secret.Data["tls.crt"])
 					if err != nil {
-						return false
+						return err
 					}
 					if len(certificates) == 0 {
-						return false
+						return fmt.Errorf("certificates length equals to 0")
 					}
 
 					now := time.Now()
 					certificate := certificates[0]
 					if now.After(certificate.NotAfter) {
-						return false
+						return fmt.Errorf("certificate after NotAfter")
 					}
 					if now.Before(certificate.NotBefore) {
-						return false
+						return fmt.Errorf("certificate before NotBefore")
 					}
 
 					if name == "signer-secret" {
@@ -439,7 +456,7 @@ var _ = ginkgo.Describe("ClusterManager", func() {
 					// ensure signing cert of serving certs in the ca bundle configmap
 					caCerts, err := cert.ParseCertsPEM([]byte(configmap.Data["ca-bundle.crt"]))
 					if err != nil {
-						return false
+						return err
 					}
 
 					found := false
@@ -448,20 +465,460 @@ var _ = ginkgo.Describe("ClusterManager", func() {
 							continue
 						}
 						if now.After(caCert.NotAfter) {
-							return false
+							return fmt.Errorf("certificate after NotAfter")
 						}
 						if now.Before(caCert.NotBefore) {
-							return false
+							return fmt.Errorf("certificate before NotBefore")
 						}
 						found = true
 						break
 					}
 					if !found {
-						return false
+						return fmt.Errorf("not found")
 					}
 				}
-				return true
-			}, eventuallyTimeout*3, eventuallyInterval*3).Should(gomega.BeTrue())
+				return nil
+			}, eventuallyTimeout*3, eventuallyInterval*3).Should(gomega.BeNil())
+		})
+	})
+})
+
+var _ = ginkgo.Describe("ClusterManager Detached Mode", func() {
+	var cancel context.CancelFunc
+	var hubRegistrationDeployment = fmt.Sprintf("%s-registration-controller", clusterManagerName)
+
+	ginkgo.BeforeEach(func() {
+		var ctx context.Context
+		ctx, cancel = context.WithCancel(context.Background())
+		go startHubOperator(ctx, v1.InstallModeDetached)
+	})
+
+	ginkgo.AfterEach(func() {
+		if cancel != nil {
+			cancel()
+		}
+	})
+
+	ginkgo.Context("Deploy and clean hub component", func() {
+		ginkgo.It("should have expected resource created successfully", func() {
+			// Check namespace
+			gomega.Eventually(func() error {
+				if _, err := detachedKubeClient.CoreV1().Namespaces().Get(context.Background(), hubNamespaceDetached, metav1.GetOptions{}); err != nil {
+					return err
+				}
+				return nil
+			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeNil())
+
+			// Check clusterrole/clusterrolebinding
+			hubRegistrationClusterRole := fmt.Sprintf("open-cluster-management:%s-registration:controller", clusterManagerName)
+			hubRegistrationWebhookClusterRole := fmt.Sprintf("open-cluster-management:%s-registration:webhook", clusterManagerName)
+			hubWorkWebhookClusterRole := fmt.Sprintf("open-cluster-management:%s-registration:webhook", clusterManagerName)
+			gomega.Eventually(func() error {
+				if _, err := detachedKubeClient.RbacV1().ClusterRoles().Get(context.Background(), hubRegistrationClusterRole, metav1.GetOptions{}); err != nil {
+					return err
+				}
+				return nil
+			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeNil())
+			gomega.Eventually(func() error {
+				if _, err := detachedKubeClient.RbacV1().ClusterRoles().Get(context.Background(), hubRegistrationWebhookClusterRole, metav1.GetOptions{}); err != nil {
+					return err
+				}
+				return nil
+			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeNil())
+			gomega.Eventually(func() error {
+				if _, err := detachedKubeClient.RbacV1().ClusterRoles().Get(context.Background(), hubWorkWebhookClusterRole, metav1.GetOptions{}); err != nil {
+					return err
+				}
+				return nil
+			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeNil())
+			gomega.Eventually(func() error {
+				if _, err := detachedKubeClient.RbacV1().ClusterRoleBindings().Get(context.Background(), hubRegistrationClusterRole, metav1.GetOptions{}); err != nil {
+					return err
+				}
+				return nil
+			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeNil())
+			gomega.Eventually(func() error {
+				if _, err := detachedKubeClient.RbacV1().ClusterRoleBindings().Get(context.Background(), hubRegistrationWebhookClusterRole, metav1.GetOptions{}); err != nil {
+					return err
+				}
+				return nil
+			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeNil())
+			gomega.Eventually(func() error {
+				if _, err := detachedKubeClient.RbacV1().ClusterRoleBindings().Get(context.Background(), hubWorkWebhookClusterRole, metav1.GetOptions{}); err != nil {
+					return err
+				}
+				return nil
+			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeNil())
+
+			// Check service account
+			hubRegistrationSA := fmt.Sprintf("%s-registration-controller-sa", clusterManagerName)
+			hubRegistrationWebhookSA := fmt.Sprintf("%s-registration-webhook-sa", clusterManagerName)
+			hubWorkWebhookSA := fmt.Sprintf("%s-work-webhook-sa", clusterManagerName)
+			gomega.Eventually(func() error {
+				if _, err := detachedKubeClient.CoreV1().ServiceAccounts(hubNamespaceDetached).Get(context.Background(), hubRegistrationSA, metav1.GetOptions{}); err != nil {
+					return err
+				}
+				return nil
+			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeNil())
+			gomega.Eventually(func() error {
+				if _, err := detachedKubeClient.CoreV1().ServiceAccounts(hubNamespaceDetached).Get(context.Background(), hubRegistrationWebhookSA, metav1.GetOptions{}); err != nil {
+					return err
+				}
+				return nil
+			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeNil())
+			gomega.Eventually(func() error {
+				if _, err := detachedKubeClient.CoreV1().ServiceAccounts(hubNamespaceDetached).Get(context.Background(), hubWorkWebhookSA, metav1.GetOptions{}); err != nil {
+					return err
+				}
+				return nil
+			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeNil())
+
+			// Check deployment
+			gomega.Eventually(func() error {
+				if _, err := detachedKubeClient.AppsV1().Deployments(hubNamespaceDetached).Get(context.Background(), hubRegistrationDeployment, metav1.GetOptions{}); err != nil {
+					return err
+				}
+				return nil
+			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeNil())
+
+			hubRegistrationWebhookDeployment := fmt.Sprintf("%s-registration-webhook", clusterManagerName)
+			gomega.Eventually(func() error {
+				if _, err := detachedKubeClient.AppsV1().Deployments(hubNamespaceDetached).Get(context.Background(), hubRegistrationWebhookDeployment, metav1.GetOptions{}); err != nil {
+					return err
+				}
+				return nil
+			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeNil())
+
+			hubWorkWebhookDeployment := fmt.Sprintf("%s-work-webhook", clusterManagerName)
+			gomega.Eventually(func() error {
+				if _, err := detachedKubeClient.AppsV1().Deployments(hubNamespaceDetached).Get(context.Background(), hubWorkWebhookDeployment, metav1.GetOptions{}); err != nil {
+					return err
+				}
+				return nil
+			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeNil())
+
+			// Check service
+			gomega.Eventually(func() error {
+				if _, err := detachedKubeClient.CoreV1().Services(hubNamespaceDetached).Get(context.Background(), "cluster-manager-registration-webhook", metav1.GetOptions{}); err != nil {
+					return err
+				}
+				return nil
+			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeNil())
+
+			gomega.Eventually(func() error {
+				if _, err := detachedKubeClient.CoreV1().Services(hubNamespaceDetached).Get(context.Background(), "cluster-manager-work-webhook", metav1.GetOptions{}); err != nil {
+					return err
+				}
+				return nil
+			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeNil())
+
+			// Check webhook secret
+			registrationWebhookSecret := "registration-webhook-serving-cert"
+			gomega.Eventually(func() error {
+				s, err := detachedKubeClient.CoreV1().Secrets(hubNamespaceDetached).Get(context.Background(), registrationWebhookSecret, metav1.GetOptions{})
+				if err != nil {
+					return err
+				}
+				if s.Data == nil {
+					return fmt.Errorf("s.Data is nil")
+				} else if s.Data["tls.crt"] == nil {
+					return fmt.Errorf("s.Data doesn't contain key 'tls.crt'")
+				} else if s.Data["tls.key"] == nil {
+					return fmt.Errorf("s.Data doesn't contain key 'tls.key'")
+				}
+				return nil
+			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeNil())
+
+			workWebhookSecret := "work-webhook-serving-cert"
+			gomega.Eventually(func() error {
+				s, err := detachedKubeClient.CoreV1().Secrets(hubNamespaceDetached).Get(context.Background(), workWebhookSecret, metav1.GetOptions{})
+				if err != nil {
+					return err
+				}
+				if s.Data == nil {
+					return fmt.Errorf("s.Data is nil")
+				} else if s.Data["tls.crt"] == nil {
+					return fmt.Errorf("s.Data doesn't contain key 'tls.crt'")
+				} else if s.Data["tls.key"] == nil {
+					return fmt.Errorf("s.Data doesn't contain key 'tls.key'")
+				}
+				return nil
+			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeNil())
+
+			// Check validating webhook
+			registrationValidtingWebhook := "managedclustervalidators.admission.cluster.open-cluster-management.io"
+			gomega.Eventually(func() error {
+				if _, err := detachedKubeClient.AdmissionregistrationV1().ValidatingWebhookConfigurations().Get(context.Background(), registrationValidtingWebhook, metav1.GetOptions{}); err != nil {
+					return err
+				}
+				return nil
+			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeNil())
+
+			workValidtingWebhook := "manifestworkvalidators.admission.work.open-cluster-management.io"
+			gomega.Eventually(func() error {
+				if _, err := detachedKubeClient.AdmissionregistrationV1().ValidatingWebhookConfigurations().Get(context.Background(), workValidtingWebhook, metav1.GetOptions{}); err != nil {
+					return err
+				}
+				return nil
+			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeNil())
+
+			util.AssertClusterManagerCondition(clusterManagerName, detachedOperatorClient, "Applied", "ClusterManagerApplied", metav1.ConditionTrue)
+		})
+
+		ginkgo.It("Deployment should be updated when clustermanager is changed", func() {
+			gomega.Eventually(func() error {
+				if _, err := detachedKubeClient.AppsV1().Deployments(hubNamespaceDetached).Get(context.Background(), hubRegistrationDeployment, metav1.GetOptions{}); err != nil {
+					return err
+				}
+				return nil
+			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeNil())
+
+			// Check if generations are correct
+			gomega.Eventually(func() error {
+				actual, err := detachedOperatorClient.OperatorV1().ClusterManagers().Get(context.Background(), clusterManagerName, metav1.GetOptions{})
+				if err != nil {
+					return err
+				}
+
+				if actual.Generation != actual.Status.ObservedGeneration {
+					return fmt.Errorf("except generation to be %d, but got %d", actual.Status.ObservedGeneration, actual.Generation)
+				}
+
+				return nil
+			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeNil())
+
+			clusterManager, err := detachedOperatorClient.OperatorV1().ClusterManagers().Get(context.Background(), clusterManagerName, metav1.GetOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			clusterManager.Spec.RegistrationImagePullSpec = "testimage:latest"
+			_, err = detachedOperatorClient.OperatorV1().ClusterManagers().Update(context.Background(), clusterManager, metav1.UpdateOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			gomega.Eventually(func() error {
+				actual, err := detachedKubeClient.AppsV1().Deployments(hubNamespaceDetached).Get(context.Background(), hubRegistrationDeployment, metav1.GetOptions{})
+				if err != nil {
+					return err
+				}
+				gomega.Expect(len(actual.Spec.Template.Spec.Containers)).Should(gomega.Equal(1))
+				if actual.Spec.Template.Spec.Containers[0].Image != "testimage:latest" {
+					return fmt.Errorf("expected image to be testimage:latest but get %s", actual.Spec.Template.Spec.Containers[0].Image)
+				}
+				return nil
+			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeNil())
+
+			// Check if generations are correct
+			gomega.Eventually(func() error {
+				actual, err := detachedOperatorClient.OperatorV1().ClusterManagers().Get(context.Background(), clusterManagerName, metav1.GetOptions{})
+				if err != nil {
+					return err
+				}
+
+				if actual.Generation != actual.Status.ObservedGeneration {
+					return fmt.Errorf("except generation to be %d, but got %d", actual.Status.ObservedGeneration, actual.Generation)
+				}
+
+				return nil
+			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeNil())
+
+			// Check if relatedResources are correct
+			gomega.Eventually(func() error {
+				actual, err := detachedOperatorClient.OperatorV1().ClusterManagers().Get(context.Background(), clusterManagerName, metav1.GetOptions{})
+				if err != nil {
+					return err
+				}
+				if len(actual.Status.RelatedResources) != 33 {
+					return fmt.Errorf("should get 33 relatedResources, actual got %v", len(actual.Status.RelatedResources))
+				}
+				return nil
+			}, eventuallyTimeout, eventuallyInterval).ShouldNot(gomega.HaveOccurred())
+
+		})
+
+		ginkgo.It("Deployment should be added nodeSelector and toleration when add nodePlacement into clustermanager", func() {
+			clusterManager, err := detachedOperatorClient.OperatorV1().ClusterManagers().Get(context.Background(), clusterManagerName, metav1.GetOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			clusterManager.Spec.NodePlacement = v1.NodePlacement{
+				NodeSelector: map[string]string{"node-role.kubernetes.io/infra": ""},
+				Tolerations: []corev1.Toleration{
+					{
+						Key:      "node-role.kubernetes.io/infra",
+						Operator: corev1.TolerationOpExists,
+						Effect:   corev1.TaintEffectNoSchedule,
+					},
+				},
+			}
+			_, err = detachedOperatorClient.OperatorV1().ClusterManagers().Update(context.Background(), clusterManager, metav1.UpdateOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			gomega.Eventually(func() error {
+				actual, err := detachedKubeClient.AppsV1().Deployments(hubNamespaceDetached).Get(context.Background(), hubRegistrationDeployment, metav1.GetOptions{})
+				if err != nil {
+					return err
+				}
+				gomega.Expect(len(actual.Spec.Template.Spec.Containers)).Should(gomega.Equal(1))
+				if len(actual.Spec.Template.Spec.NodeSelector) == 0 {
+					return fmt.Errorf("length of node selector should not equals to 0")
+				}
+				if _, ok := actual.Spec.Template.Spec.NodeSelector["node-role.kubernetes.io/infra"]; !ok {
+					return fmt.Errorf("node-role.kubernetes.io/infra not exist")
+				}
+				if len(actual.Spec.Template.Spec.Tolerations) == 0 {
+					return fmt.Errorf("length of node selecor should not equals to 0")
+				}
+				for _, toleration := range actual.Spec.Template.Spec.Tolerations {
+					if toleration.Key == "node-role.kubernetes.io/infra" {
+						return nil
+					}
+				}
+
+				return fmt.Errorf("no key equals to node-role.kubernetes.io/infra")
+			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeNil())
+		})
+		ginkgo.It("Deployment should be reconciled when manually updated", func() {
+			gomega.Eventually(func() error {
+				if _, err := detachedKubeClient.AppsV1().Deployments(hubNamespaceDetached).Get(context.Background(), hubRegistrationDeployment, metav1.GetOptions{}); err != nil {
+					return err
+				}
+				return nil
+			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeNil())
+			registrationoDeployment, err := detachedKubeClient.AppsV1().Deployments(hubNamespaceDetached).Get(context.Background(), hubRegistrationDeployment, metav1.GetOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			registrationoDeployment.Spec.Template.Spec.Containers[0].Image = "testimage2:latest"
+			_, err = detachedKubeClient.AppsV1().Deployments(hubNamespaceDetached).Update(context.Background(), registrationoDeployment, metav1.UpdateOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Eventually(func() error {
+				registrationoDeployment, err := detachedKubeClient.AppsV1().Deployments(hubNamespaceDetached).Get(context.Background(), hubRegistrationDeployment, metav1.GetOptions{})
+				if err != nil {
+					return err
+				}
+				if registrationoDeployment.Spec.Template.Spec.Containers[0].Image != "testimage:latest" {
+					return fmt.Errorf("image should be testimage:latest, but get %s", registrationoDeployment.Spec.Template.Spec.Containers[0].Image)
+				}
+				return nil
+			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeNil())
+
+			// Check if generations are correct
+			gomega.Eventually(func() error {
+				actual, err := detachedOperatorClient.OperatorV1().ClusterManagers().Get(context.Background(), clusterManagerName, metav1.GetOptions{})
+				if err != nil {
+					return err
+				}
+
+				registrationDeployment, err := detachedKubeClient.AppsV1().Deployments(hubNamespaceDetached).Get(context.Background(), hubRegistrationDeployment, metav1.GetOptions{})
+				if err != nil {
+					return err
+				}
+
+				deploymentGeneration := helpers.NewGenerationStatus(appsv1.SchemeGroupVersion.WithResource("deployments"), registrationDeployment)
+				actualGeneration := helpers.FindGenerationStatus(actual.Status.Generations, deploymentGeneration)
+				if deploymentGeneration.LastGeneration != actualGeneration.LastGeneration {
+					return fmt.Errorf("expected LastGeneration shoud be %d, but get %d", actualGeneration.LastGeneration, deploymentGeneration.LastGeneration)
+				}
+				return nil
+			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeNil())
+		})
+	})
+
+	ginkgo.Context("Cluster manager statuses", func() {
+		ginkgo.It("should have correct degraded conditions", func() {
+			gomega.Eventually(func() error {
+				if _, err := detachedKubeClient.AppsV1().Deployments(hubNamespaceDetached).Get(context.Background(), hubRegistrationDeployment, metav1.GetOptions{}); err != nil {
+					return err
+				}
+				return nil
+			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeNil())
+
+			// The cluster manager should be unavailable at first
+			util.AssertClusterManagerCondition(clusterManagerName, detachedOperatorClient, "HubRegistrationDegraded", "UnavailableRegistrationPod", metav1.ConditionTrue)
+
+			// Update replica of deployment
+			registrationDeployment, err := detachedKubeClient.AppsV1().Deployments(hubNamespaceDetached).Get(context.Background(), hubRegistrationDeployment, metav1.GetOptions{})
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			registrationDeployment.Status.AvailableReplicas = 3
+			registrationDeployment.Status.Replicas = 3
+			registrationDeployment.Status.ReadyReplicas = 3
+			_, err = detachedKubeClient.AppsV1().Deployments(hubNamespaceDetached).UpdateStatus(context.Background(), registrationDeployment, metav1.UpdateOptions{})
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+			// The cluster manager should be functional at last
+			util.AssertClusterManagerCondition(clusterManagerName, detachedOperatorClient, "HubRegistrationDegraded", "RegistrationFunctional", metav1.ConditionFalse)
+		})
+	})
+
+	ginkgo.Context("Serving cert rotation", func() {
+		ginkgo.It("should rotate both serving cert and signing cert before they become expired", func() {
+			secretNames := []string{"signer-secret", "registration-webhook-serving-cert", "work-webhook-serving-cert"}
+			// wait until all secrets and configmap are in place
+			gomega.Eventually(func() error {
+				for _, name := range secretNames {
+					if _, err := detachedKubeClient.CoreV1().Secrets(hubNamespaceDetached).Get(context.Background(), name, metav1.GetOptions{}); err != nil {
+						return err
+					}
+				}
+				if _, err := detachedKubeClient.CoreV1().ConfigMaps(hubNamespaceDetached).Get(context.Background(), "ca-bundle-configmap", metav1.GetOptions{}); err != nil {
+					return err
+				}
+				return nil
+			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeNil())
+
+			// both serving cert and signing cert should aways be valid
+			gomega.Consistently(func() error {
+				configmap, err := detachedKubeClient.CoreV1().ConfigMaps(hubNamespaceDetached).Get(context.Background(), "ca-bundle-configmap", metav1.GetOptions{})
+				if err != nil {
+					return err
+				}
+				for _, name := range []string{"signer-secret", "registration-webhook-serving-cert", "work-webhook-serving-cert"} {
+					secret, err := detachedKubeClient.CoreV1().Secrets(hubNamespaceDetached).Get(context.Background(), name, metav1.GetOptions{})
+					if err != nil {
+						return err
+					}
+
+					certificates, err := cert.ParseCertsPEM(secret.Data["tls.crt"])
+					if err != nil {
+						return err
+					}
+					if len(certificates) == 0 {
+						return fmt.Errorf("certificates length equals to 0")
+					}
+
+					now := time.Now()
+					certificate := certificates[0]
+					if now.After(certificate.NotAfter) {
+						return fmt.Errorf("certificate after NotAfter")
+					}
+					if now.Before(certificate.NotBefore) {
+						return fmt.Errorf("certificate before NotBefore")
+					}
+
+					if name == "signer-secret" {
+						continue
+					}
+
+					// ensure signing cert of serving certs in the ca bundle configmap
+					caCerts, err := cert.ParseCertsPEM([]byte(configmap.Data["ca-bundle.crt"]))
+					if err != nil {
+						return err
+					}
+
+					found := false
+					for _, caCert := range caCerts {
+						if certificate.Issuer.CommonName != caCert.Subject.CommonName {
+							continue
+						}
+						if now.After(caCert.NotAfter) {
+							return fmt.Errorf("certificate after NotAfter")
+						}
+						if now.Before(caCert.NotBefore) {
+							return fmt.Errorf("certificate before NotBefore")
+						}
+						found = true
+						break
+					}
+					if !found {
+						return fmt.Errorf("not found")
+					}
+				}
+				return nil
+			}, eventuallyTimeout*3, eventuallyInterval*3).Should(gomega.BeNil())
 		})
 	})
 })


### PR DESCRIPTION
Signed-off-by: xuezhaojun <zxue@redhat.com>

https://github.com/open-cluster-management-io/registration-operator/issues/157

Please note that this PR is scoped, it only supports detached mode install in a customize namespace, but in any other way, it behaves just like the default mode.
Therefore there are no test cases for the logic of detached mode. The rest of detached mode will come with another PR later.