### PR TITLE
get the namespace of klusterlet from helper

### DIFF
--- a/pkg/helpers/helpers.go
+++ b/pkg/helpers/helpers.go
@@ -603,17 +603,17 @@ func UpdateKlusterletRelatedResourcesFn(relatedResources ...operatorapiv1.Relate
 
 // KlusterletNamespace returns the klusterletNamespace to deploy the agents.
 // Note in Detached mode, the specNamespace will be ignored.
-func KlusterletNamespace(mode operatorapiv1.InstallMode, klusterletName, specNamespace string) string {
-	if mode == operatorapiv1.InstallModeDetached {
-		return klusterletName
+func KlusterletNamespace(klusterlet *operatorapiv1.Klusterlet) string {
+	if klusterlet.Spec.DeployOption.Mode == operatorapiv1.InstallModeDetached {
+		return klusterlet.GetName()
 	}
 
-	if len(specNamespace) == 0 {
+	if len(klusterlet.Spec.Namespace) == 0 {
 		// If namespace is not set, use the default namespace
 		return KlusterletDefaultNamespace
 	}
 
-	return specNamespace
+	return klusterlet.Spec.Namespace
 }
 
 // SyncSecret forked from https://github.com/openshift/library-go/blob/d9cdfbd844ea08465b938c46a16bed2ea23207e4/pkg/operator/resource/resourceapply/core.go#L357,

--- a/pkg/helpers/helpers_test.go
+++ b/pkg/helpers/helpers_test.go
@@ -930,43 +930,65 @@ func TestUpdateRelatedResources(t *testing.T) {
 
 func TestKlusterletNamespace(t *testing.T) {
 	testcases := []struct {
-		name           string
-		klusterletName string
-		specNamespace  string
-		mode           operatorapiv1.InstallMode
-		expect         string
+		name       string
+		klusterlet *operatorapiv1.Klusterlet
+		expect     string
 	}{
 		{
-			name:          "Default mode without spec namespace",
-			specNamespace: "",
-			mode:          "",
-			expect:        KlusterletDefaultNamespace,
+			name: "Default mode without spec namespace",
+			klusterlet: &operatorapiv1.Klusterlet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "klusterlet",
+				},
+				Spec: operatorapiv1.KlusterletSpec{
+					Namespace:    "",
+					DeployOption: operatorapiv1.DeployOption{},
+				}},
+			expect: KlusterletDefaultNamespace,
 		},
 		{
-			name:          "Default mode with spec namespace",
-			specNamespace: "open-cluster-management-test",
-			mode:          "",
-			expect:        "open-cluster-management-test",
+			name: "Default mode with spec namespace",
+			klusterlet: &operatorapiv1.Klusterlet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "klusterlet",
+				},
+				Spec: operatorapiv1.KlusterletSpec{
+					Namespace:    "open-cluster-management-test",
+					DeployOption: operatorapiv1.DeployOption{},
+				}},
+			expect: "open-cluster-management-test",
 		},
 		{
-			name:           "Detached mode with spec namespace",
-			klusterletName: "klusterlet",
-			specNamespace:  "open-cluster-management-test",
-			mode:           operatorapiv1.InstallModeDetached,
-			expect:         "klusterlet",
+			name: "Detached mode with spec namespace",
+			klusterlet: &operatorapiv1.Klusterlet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "klusterlet",
+				},
+				Spec: operatorapiv1.KlusterletSpec{
+					Namespace:    "open-cluster-management-test",
+					DeployOption: operatorapiv1.DeployOption{Mode: operatorapiv1.InstallModeDetached},
+				},
+			},
+			expect: "klusterlet",
 		},
 		{
-			name:           "Detached mode without spec namespace",
-			klusterletName: "klusterlet",
-			specNamespace:  "",
-			mode:           operatorapiv1.InstallModeDetached,
-			expect:         "klusterlet",
+			name: "Detached mode without spec namespace",
+			klusterlet: &operatorapiv1.Klusterlet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "klusterlet",
+				},
+				Spec: operatorapiv1.KlusterletSpec{
+					Namespace:    "",
+					DeployOption: operatorapiv1.DeployOption{Mode: operatorapiv1.InstallModeDetached},
+				},
+			},
+			expect: "klusterlet",
 		},
 	}
 
 	for _, c := range testcases {
 		t.Run(c.name, func(t *testing.T) {
-			namespace := KlusterletNamespace(c.mode, c.klusterletName, c.specNamespace)
+			namespace := KlusterletNamespace(c.klusterlet)
 			if namespace != c.expect {
 				t.Errorf("Expect namespace %v, got %v", c.expect, namespace)
 			}

--- a/pkg/helpers/queuekey.go
+++ b/pkg/helpers/queuekey.go
@@ -159,7 +159,7 @@ func clusterManagerByNamespaceQueueKeyFunc(clusterManagerLister operatorlister.C
 
 func FindKlusterletByNamespace(klusterlets []*operatorapiv1.Klusterlet, namespace string) *operatorapiv1.Klusterlet {
 	for _, klusterlet := range klusterlets {
-		klusterletNS := KlusterletNamespace(klusterlet.Spec.DeployOption.Mode, klusterlet.Name, klusterlet.Spec.Namespace)
+		klusterletNS := KlusterletNamespace(klusterlet)
 		if namespace == klusterletNS {
 			return klusterlet
 		}

--- a/pkg/operators/klusterlet/controllers/bootstrapcontroller/bootstrapcontroller.go
+++ b/pkg/operators/klusterlet/controllers/bootstrapcontroller/bootstrapcontroller.go
@@ -83,7 +83,7 @@ func (k *bootstrapController) sync(ctx context.Context, controllerContext factor
 		}
 
 		for _, klusterlet := range klusterlets {
-			namespace := helpers.KlusterletNamespace(klusterlet.Spec.DeployOption.Mode, klusterletName, klusterlet.Spec.Namespace)
+			namespace := helpers.KlusterletNamespace(klusterlet)
 			// enqueue the klusterlet to reconcile
 			controllerContext.Queue().Add(fmt.Sprintf("%s/%s", namespace, klusterlet.Name))
 		}

--- a/pkg/operators/klusterlet/controllers/klusterletcontroller/klusterlet_controller.go
+++ b/pkg/operators/klusterlet/controllers/klusterletcontroller/klusterlet_controller.go
@@ -44,8 +44,6 @@ const (
 	klusterletApplied            = "Applied"
 	klusterletReadyToApply       = "ReadyToApply"
 	appliedManifestWorkFinalizer = "cluster.open-cluster-management.io/applied-manifest-work-cleanup"
-	defaultReplica               = 3
-	singleReplica                = 1
 )
 
 var (
@@ -191,7 +189,7 @@ func (n *klusterletController) sync(ctx context.Context, controllerContext facto
 
 	config := klusterletConfig{
 		KlusterletName:            klusterlet.Name,
-		KlusterletNamespace:       helpers.KlusterletNamespace(klusterlet.Spec.DeployOption.Mode, klusterletName, klusterlet.Spec.Namespace),
+		KlusterletNamespace:       helpers.KlusterletNamespace(klusterlet),
 		RegistrationImage:         klusterlet.Spec.RegistrationImagePullSpec,
 		WorkImage:                 klusterlet.Spec.WorkImagePullSpec,
 		ClusterName:               klusterlet.Spec.ClusterName,

--- a/pkg/operators/klusterlet/controllers/klusterletcontroller/klusterlet_controller_test.go
+++ b/pkg/operators/klusterlet/controllers/klusterletcontroller/klusterlet_controller_test.go
@@ -181,7 +181,7 @@ func newTestControllerDetached(klusterlet *opratorapiv1.Klusterlet, appliedManif
 	operatorInformers := operatorinformers.NewSharedInformerFactory(fakeOperatorClient, 5*time.Minute)
 	kubeVersion, _ := version.ParseGeneric("v1.18.0")
 
-	installedNamespace := helpers.KlusterletNamespace(klusterlet.Spec.DeployOption.Mode, klusterlet.Name, klusterlet.Spec.Namespace)
+	installedNamespace := helpers.KlusterletNamespace(klusterlet)
 	saRegistrationSecret := newServiceAccountSecret(fmt.Sprintf("%s-token", registrationServiceAccountName(klusterlet.Name)), klusterlet.Name)
 	saWorkSecret := newServiceAccountSecret(fmt.Sprintf("%s-token", workServiceAccountName(klusterlet.Name)), klusterlet.Name)
 	fakeManagedKubeClient := fakekube.NewSimpleClientset()
@@ -362,7 +362,7 @@ func ensureObject(t *testing.T, object runtime.Object, klusterlet *opratorapiv1.
 		t.Errorf("Unable to access objectmeta: %v", err)
 	}
 
-	namespace := helpers.KlusterletNamespace(klusterlet.Spec.DeployOption.Mode, klusterlet.Name, klusterlet.Spec.Namespace)
+	namespace := helpers.KlusterletNamespace(klusterlet)
 	switch o := object.(type) {
 	case *appsv1.Deployment:
 		if strings.Contains(access.GetName(), "registration") {
@@ -612,7 +612,7 @@ func TestSyncDeleteDetached(t *testing.T) {
 	klusterlet := newKlusterletDetached("klusterlet", "testns", "cluster1")
 	now := metav1.Now()
 	klusterlet.ObjectMeta.SetDeletionTimestamp(&now)
-	installedNamespace := helpers.KlusterletNamespace(klusterlet.Spec.DeployOption.Mode, klusterlet.Name, klusterlet.Spec.Namespace)
+	installedNamespace := helpers.KlusterletNamespace(klusterlet)
 	bootstrapKubeConfigSecret := newSecret(helpers.BootstrapHubKubeConfig, installedNamespace)
 	bootstrapKubeConfigSecret.Data["kubeconfig"] = newKubeConfig("testhost")
 	// externalManagedSecret := newSecret(helpers.ExternalManagedKubeConfig, installedNamespace)

--- a/pkg/operators/klusterlet/controllers/ssarcontroller/klusterlet_ssar_controller.go
+++ b/pkg/operators/klusterlet/controllers/ssarcontroller/klusterlet_ssar_controller.go
@@ -44,7 +44,6 @@ type klusterletLocker struct {
 }
 
 const (
-	klusterletNamespace     = "open-cluster-management-agent"
 	bootstrapSecret         = "BootstrapSecret"
 	bootstrapSecretDegraded = "BootstrapSecretDegraded"
 	hubConfigSecret         = "HubConfigSecret"
@@ -123,10 +122,7 @@ func (c *ssarController) sync(ctx context.Context, controllerContext factory.Syn
 		defer c.deleteSSARChecking(klusterletName)
 
 		klog.V(4).Infof("Reconciling Klusterlet %q", klusterletName)
-		klusterletNS := klusterlet.Spec.Namespace
-		if klusterletNS == "" {
-			klusterletNS = klusterletNamespace
-		}
+		klusterletNS := helpers.KlusterletNamespace(klusterlet)
 
 		hubConfigDegradedCondition := checkAgentDegradedCondition(
 			ctx, c.kubeClient,

--- a/pkg/operators/klusterlet/controllers/statuscontroller/klusterlet_status_controller.go
+++ b/pkg/operators/klusterlet/controllers/statuscontroller/klusterlet_status_controller.go
@@ -68,7 +68,7 @@ func (k *klusterletStatusController) sync(ctx context.Context, controllerContext
 	}
 	klusterlet = klusterlet.DeepCopy()
 
-	klusterletNS := helpers.KlusterletNamespace(klusterlet.Spec.DeployOption.Mode, klusterletName, klusterlet.Spec.Namespace)
+	klusterletNS := helpers.KlusterletNamespace(klusterlet)
 	registrationDeploymentName := fmt.Sprintf("%s-registration-agent", klusterlet.Name)
 	workDeploymentName := fmt.Sprintf("%s-work-agent", klusterlet.Name)
 

--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -169,7 +169,7 @@ func (t *Tester) CreateKlusterlet(name, clusterName, agentNamespace string, mode
 		},
 	}
 
-	agentNamespace = helpers.KlusterletNamespace(klusterlet.Spec.DeployOption.Mode, klusterlet.Name, klusterlet.Spec.Namespace)
+	agentNamespace = helpers.KlusterletNamespace(klusterlet)
 	klog.Infof("klusterlet: %s/%s, \t mode: %v, \t agent namespace: %s", klusterlet.Name, klusterlet.Namespace, mode, agentNamespace)
 
 	// create agentNamespace


### PR DESCRIPTION
refactor the helper.KlusterletNamespace() 
fix the issue that HubConfigSecretDegraded  condation cannot be  recovered in detach mode since the ns of klusterlet is incorrect. 
Signed-off-by: Zhiwei Yin <zyin@redhat.com>