### PR TITLE
leader election needs to operate configmaps and leases

### DIFF
--- a/manifests/klusterlet/management/klusterlet-registration-role.yaml
+++ b/manifests/klusterlet/management/klusterlet-registration-role.yaml
@@ -6,7 +6,14 @@ metadata:
   name: open-cluster-management:management:{{ .KlusterletName }}-registration:agent
   namespace: {{ .AgentNamespace }}
 rules:
-# leader election needs to operate configmaps, create hub-kubeconfig external-managed-registration/work secrets
+# leader election needs to operate configmaps and leases
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["get", "list", "watch", "create", "delete", "update", "patch"]
+- apiGroups: ["coordination.k8s.io"]
+  resources: ["leases"]
+  verbs: ["create", "get", "list", "update", "watch", "patch"]
+# create hub-kubeconfig external-managed-registration/work secrets
 # TODO(zhujian7): may be replaced by a clusterrole to grant secret operation for others namespaces when addon
 # agents are supported running on the management cluster
 - apiGroups: [""]

--- a/manifests/klusterlet/management/klusterlet-work-role.yaml
+++ b/manifests/klusterlet/management/klusterlet-work-role.yaml
@@ -6,7 +6,7 @@ metadata:
   name: open-cluster-management:management:{{ .KlusterletName }}-work:agent
   namespace: {{ .AgentNamespace }}
 rules:
-# leader election needs to operate configmaps
+# leader election needs to operate configmaps and leases
 - apiGroups: [""]
   resources: ["configmaps"]
   verbs: ["get", "list", "watch", "create", "delete", "update", "patch"]


### PR DESCRIPTION
registration meets below error when enable leader election
```
E0704 06:12:56.451744       1 leaderelection.go:330] error retrieving resource lock open-cluster-management-agent/registration-agent-lock: configmaps “registration-agent-lock” is forbidden: User “system:serviceaccount:open-cluster-management-agent:klusterlet-registration-sa” cannot get resource “configmaps” in API group “” in the namespace “open-cluster-management-agent”
```
to fix this error, add configmaps and lease permission back.

Signed-off-by: haoqing0110 <qhao@redhat.com>