### PR TITLE
Fix: delete addon crd at first

### DIFF
--- a/pkg/operators/clustermanager/controllers/clustermanagercontroller/clustermanager_controller.go
+++ b/pkg/operators/clustermanager/controllers/clustermanagercontroller/clustermanager_controller.go
@@ -35,7 +35,11 @@ import (
 )
 
 var (
+	// crdNames is the list of CRDs to be wiped out before deleting other resources when clusterManager is deleted.
+	// The order of the list matters, the managedclusteraddon crd needs to be deleted at first so all addon related
+	// manifestwork is deleted, then other manifestworks.
 	crdNames = []string{
+		"managedclusteraddons.addon.open-cluster-management.io",
 		"manifestworks.work.open-cluster-management.io",
 		"managedclusters.cluster.open-cluster-management.io",
 	}

--- a/pkg/operators/clustermanager/controllers/clustermanagercontroller/clustermanager_controller_test.go
+++ b/pkg/operators/clustermanager/controllers/clustermanagercontroller/clustermanager_controller_test.go
@@ -222,7 +222,7 @@ func TestSyncDelete(t *testing.T) {
 		}
 	}
 	// Check if resources are created as expected
-	testinghelper.AssertEqualNumber(t, len(deleteCRDActions), 12)
+	testinghelper.AssertEqualNumber(t, len(deleteCRDActions), 13)
 
 	deleteAPIServiceActions := []clienttesting.DeleteActionImpl{}
 	apiServiceActions := tc.apiRegistrationClient.Actions()


### PR DESCRIPTION
This is to ensure manifestwork of addon is deleted at first.

Signed-off-by: Jian Qiu <jqiu@redhat.com>