### PR TITLE
regenerate and load hosted secrets when ca changes

### DIFF
--- a/manifests/klusterlet/management/klusterlet-registration-deployment.yaml
+++ b/manifests/klusterlet/management/klusterlet-registration-deployment.yaml
@@ -63,7 +63,9 @@ spec:
           {{end}}
           {{if eq .InstallMode "Hosted"}}
           - "--spoke-kubeconfig=/spoke/config/kubeconfig"
+          - "--terminate-on-files=/spoke/config/kubeconfig"
           {{end}}
+          - "--terminate-on-files=/spoke/hub-kubeconfig/kubeconfig"
           {{if eq .Replica 1}}
           - "--disable-leader-election"
           {{end}}

--- a/manifests/klusterlet/management/klusterlet-work-deployment.yaml
+++ b/manifests/klusterlet/management/klusterlet-work-deployment.yaml
@@ -61,7 +61,9 @@ spec:
           {{ end }}
           {{if eq .InstallMode "Hosted"}}
           - "--spoke-kubeconfig=/spoke/config/kubeconfig"
+          - "--terminate-on-files=/spoke/config/kubeconfig"
           {{end}}
+          - "--terminate-on-files=/spoke/hub-kubeconfig/kubeconfig"
           {{if eq .Replica 1}}
           - "--disable-leader-election"
           {{end}}

--- a/pkg/operators/klusterlet/controllers/klusterletcontroller/klusterlet_controller_test.go
+++ b/pkg/operators/klusterlet/controllers/klusterletcontroller/klusterlet_controller_test.go
@@ -357,6 +357,8 @@ func assertRegistrationDeployment(t *testing.T, actions []clienttesting.Action, 
 		expectedArgs = append(expectedArgs, fmt.Sprintf("--spoke-external-server-urls=%s", serverURL))
 	}
 
+	expectedArgs = append(expectedArgs, "--terminate-on-files=/spoke/hub-kubeconfig/kubeconfig")
+
 	if *deployment.Spec.Replicas == 1 {
 		expectedArgs = append(expectedArgs, "--disable-leader-election")
 	}
@@ -393,7 +395,9 @@ func assertWorkDeployment(t *testing.T, actions []clienttesting.Action, verb, cl
 
 	if mode == operatorapiv1.InstallModeHosted {
 		expectArgs = append(expectArgs, "--spoke-kubeconfig=/spoke/config/kubeconfig")
+		expectArgs = append(expectArgs, "--terminate-on-files=/spoke/config/kubeconfig")
 	}
+	expectArgs = append(expectArgs, "--terminate-on-files=/spoke/hub-kubeconfig/kubeconfig")
 
 	if *deployment.Spec.Replicas == 1 {
 		expectArgs = append(expectArgs, "--disable-leader-election")

--- a/test/integration/klusterlet_test.go
+++ b/test/integration/klusterlet_test.go
@@ -495,7 +495,7 @@ var _ = ginkgo.Describe("Klusterlet", func() {
 				gomega.Expect(len(actual.Spec.Template.Spec.Containers)).Should(gomega.Equal(1))
 				// klusterlet has no condition, replica is 0
 				gomega.Expect(actual.Status.Replicas).Should(gomega.Equal(int32(0)))
-				gomega.Expect(len(actual.Spec.Template.Spec.Containers[0].Args)).Should(gomega.Equal(6))
+				gomega.Expect(len(actual.Spec.Template.Spec.Containers[0].Args)).Should(gomega.Equal(7))
 				return actual.Spec.Template.Spec.Containers[0].Args[2] != "--spoke-cluster-name=cluster2"
 			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeTrue())
 
@@ -505,7 +505,7 @@ var _ = ginkgo.Describe("Klusterlet", func() {
 					return false
 				}
 				gomega.Expect(len(actual.Spec.Template.Spec.Containers)).Should(gomega.Equal(1))
-				gomega.Expect(len(actual.Spec.Template.Spec.Containers[0].Args)).Should(gomega.Equal(7))
+				gomega.Expect(len(actual.Spec.Template.Spec.Containers[0].Args)).Should(gomega.Equal(8))
 				return actual.Spec.Template.Spec.Containers[0].Args[2] == "--cluster-name=cluster2"
 			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeTrue())
 


### PR DESCRIPTION
- check if the host and ca chengs in the `external-managed-kubeconfig` secret, if it does, regenerate the `external-managed-kubeconfig-registration` and `external-managed-kubeconfig-work`
- use the `--terminate-on-files` flag to watch the hub/spoke kubeconfig file, if there is any change, restart the pod. there is one side effect for the registration-agent, before this change: the regisatrion can reload the hub kubeconfig when it is generated first time(importing cluster, bootstrap secret -> hub kubeconfig secret) without restarting pod. but with the change, the registration-agent will restart. if we want to prevent the side effect, we can use https://github.com/open-cluster-management-io/registration/pull/295, but it is complicated.

Signed-off-by: zhujian <jiazhu@redhat.com>