### PR TITLE
check managed cluster connectivity when deleting klusterlet

### DIFF
--- a/pkg/operators/klusterlet/controllers/klusterletcontroller/klusterlet_cleanup_controller.go
+++ b/pkg/operators/klusterlet/controllers/klusterletcontroller/klusterlet_cleanup_controller.go
@@ -3,6 +3,8 @@ package klusterletcontroller
 import (
 	"context"
 	"reflect"
+	"strings"
+	"time"
 
 	"github.com/openshift/library-go/pkg/assets"
 	"github.com/openshift/library-go/pkg/controller/factory"
@@ -133,7 +135,6 @@ func (n *klusterletCleanupController) sync(ctx context.Context, controllerContex
 			withMode(config.InstallMode).
 			withKubeConfigSecret(config.AgentNamespace, config.ExternalManagedKubeConfigSecret).
 			build(ctx)
-
 		// stop when hosted kubeconfig is not found. the klustelet controller will monitor the secret and retrigger
 		// reconcilation of cleanup controller when secret is created again.
 		if errors.IsNotFound(err) {
@@ -143,20 +144,35 @@ func (n *klusterletCleanupController) sync(ctx context.Context, controllerContex
 			return err
 		}
 
-		reconcilers = append(reconcilers,
-			&crdReconcile{
-				managedClusterClients: managedClusterClients,
-				kubeVersion:           n.kubeVersion,
-				recorder:              controllerContext.Recorder(),
-			},
-			&managedReconcile{
-				managedClusterClients: managedClusterClients,
-				kubeClient:            n.kubeClient,
-				kubeVersion:           n.kubeVersion,
-				opratorNamespace:      n.operatorNamespace,
-				recorder:              controllerContext.Recorder(),
-			},
-		)
+		// check the managed cluster connectivity
+		cleanupManagedClusterResources, err := n.checkConnectivity(ctx, managedClusterClients.appliedManifestWorkClient, klusterlet)
+		if err != nil {
+			errs := []error{err}
+			// compare the annotation to check whether the eviction timestamp has changed
+			if err := n.updateKlusterletAnnotation(ctx, klusterlet.Name, klusterlet.Annotations); err != nil {
+				errs = append(errs, err)
+			}
+			return utilerrors.NewAggregate(errs)
+		}
+
+		// after trying to connect to the managed cluster times out for a period of time, we will stop removing
+		// resources on managed clusters, but just clean the resources on the hosting cluster and finish the cleanup
+		if cleanupManagedClusterResources {
+			reconcilers = append(reconcilers,
+				&crdReconcile{
+					managedClusterClients: managedClusterClients,
+					kubeVersion:           n.kubeVersion,
+					recorder:              controllerContext.Recorder(),
+				},
+				&managedReconcile{
+					managedClusterClients: managedClusterClients,
+					kubeClient:            n.kubeClient,
+					kubeVersion:           n.kubeVersion,
+					opratorNamespace:      n.operatorNamespace,
+					recorder:              controllerContext.Recorder(),
+				},
+			)
+		}
 	}
 	// managementReconcile should be added as the last one, since we finally need to remove agent namespace.
 	reconcilers = append(reconcilers, &managementReconcile{
@@ -178,16 +194,64 @@ func (n *klusterletCleanupController) sync(ctx context.Context, controllerContex
 	}
 
 	if len(errs) > 0 {
-		klog.Errorf("Cleanup resources for Klusterlet %q error: %v", klusterletName, err)
-
-		// compare the annotation to check whether the eviction timestamp has changed
-		if err := n.updateKlusterletAnnotation(ctx, klusterlet.Name, klusterlet.Annotations); err != nil {
-			return err
-		}
 		return utilerrors.NewAggregate(errs)
 	}
 
 	return n.removeKlusterletFinalizers(ctx, klusterlet.Name)
+}
+
+func (r *klusterletCleanupController) checkConnectivity(ctx context.Context,
+	amwClient workv1client.AppliedManifestWorkInterface,
+	klusterlet *operatorapiv1.Klusterlet) (cleanupManagedClusterResources bool, err error) {
+	_, err = amwClient.List(ctx, metav1.ListOptions{})
+	if err == nil {
+		return true, nil
+	}
+
+	// if the managed cluster is destroyed, the returned err is TCP timeout or TCP no such host,
+	// the k8s.io/apimachinery/pkg/api/errors.IsTimeout,IsServerTimeout can not match this error
+	if isTCPTimeOutError(err) || isTCPNoSuchHostError(err) {
+		klog.Infof("Check the connectivity, err: %v", err)
+		if klusterlet.Annotations == nil {
+			klusterlet.Annotations = make(map[string]string, 0)
+		}
+
+		evictionTimeStr, ok := klusterlet.Annotations[managedResourcesEvictionTimestampAnno]
+		if !ok {
+			klusterlet.Annotations[managedResourcesEvictionTimestampAnno] = time.Now().Format(time.RFC3339)
+			return true, err
+		}
+		evictionTime, perr := time.Parse(time.RFC3339, evictionTimeStr)
+		if perr != nil {
+			klog.Infof("Parse eviction time %v error %s", evictionTimeStr, perr)
+			klusterlet.Annotations[managedResourcesEvictionTimestampAnno] = time.Now().Format(time.RFC3339)
+			return true, err
+		}
+
+		if evictionTime.Add(5 * time.Minute).Before(time.Now()) {
+			klog.Infof("Try to connect managed cluster timed out for 5 minutes, ignore the resources")
+			// ignore the resources on the managed cluster, return false here
+			return false, nil
+		}
+
+		return true, err
+	}
+
+	// It may be temporarily unreachable, but now it is reachable, delete the timestamp
+	delete(klusterlet.Annotations, managedResourcesEvictionTimestampAnno)
+	return true, err
+}
+
+func isTCPTimeOutError(err error) bool {
+	return err != nil &&
+		strings.Contains(err.Error(), "dial tcp") &&
+		strings.Contains(err.Error(), "i/o timeout")
+}
+
+func isTCPNoSuchHostError(err error) bool {
+	return err != nil &&
+		strings.Contains(err.Error(), "dial tcp: lookup") &&
+		strings.Contains(err.Error(), "no such host")
 }
 
 func (n *klusterletCleanupController) updateKlusterletAnnotation(

--- a/pkg/operators/klusterlet/controllers/klusterletcontroller/klusterlet_managed_reconcile.go
+++ b/pkg/operators/klusterlet/controllers/klusterletcontroller/klusterlet_managed_reconcile.go
@@ -7,8 +7,6 @@ package klusterletcontroller
 import (
 	"context"
 	"fmt"
-	"time"
-
 	"github.com/openshift/library-go/pkg/assets"
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
@@ -18,7 +16,6 @@ import (
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/klog/v2"
 	operatorapiv1 "open-cluster-management.io/api/operator/v1"
 
 	"open-cluster-management.io/registration-operator/manifests"
@@ -134,15 +131,6 @@ func (r *managedReconcile) clean(ctx context.Context, klusterlet *operatorapiv1.
 		return klusterlet, reconcileContinue, nil
 	}
 
-	// check the managed cluster connectivity
-	stop, err := r.checkConnectivity(ctx, klusterlet)
-	if err != nil {
-		return klusterlet, reconcileStop, err
-	}
-	if stop == reconcileStop {
-		return klusterlet, reconcileContinue, nil
-	}
-
 	if err := r.cleanUpAppliedManifestWorks(ctx, klusterlet, config); err != nil {
 		return klusterlet, reconcileStop, err
 	}
@@ -171,42 +159,6 @@ func (r *managedReconcile) clean(ctx context.Context, klusterlet *operatorapiv1.
 	}
 
 	return klusterlet, reconcileContinue, nil
-}
-
-func (r *managedReconcile) checkConnectivity(ctx context.Context,
-	klusterlet *operatorapiv1.Klusterlet) (reconcileState, error) {
-	_, err := r.managedClusterClients.appliedManifestWorkClient.List(ctx, metav1.ListOptions{})
-	if err == nil {
-		return reconcileContinue, nil
-	}
-
-	if errors.IsTimeout(err) || errors.IsServerTimeout(err) {
-		klog.Infof("Check the connectivity timeout")
-		if klusterlet.Annotations == nil {
-			klusterlet.Annotations = make(map[string]string, 0)
-		}
-
-		evictionTimeStr, ok := klusterlet.Annotations[managedResourcesEvictionTimestampAnno]
-		if !ok {
-			klusterlet.Annotations[managedResourcesEvictionTimestampAnno] = time.Now().Format(time.RFC3339)
-			return reconcileStop, err
-		}
-		evictionTime, perr := time.Parse(time.RFC3339, evictionTimeStr)
-		if perr != nil {
-			klog.Infof("Parse eviction time %v error %s", evictionTimeStr, perr)
-			klusterlet.Annotations[managedResourcesEvictionTimestampAnno] = time.Now().Format(time.RFC3339)
-			return reconcileStop, err
-		}
-
-		if evictionTime.Add(5 * time.Minute).Before(time.Now()) {
-			klog.Infof("Try to connect managed cluster timed out for 5 minutes, ignore the resources")
-			return reconcileStop, nil
-		}
-
-	}
-
-	delete(klusterlet.Annotations, managedResourcesEvictionTimestampAnno)
-	return reconcileStop, err
 }
 
 // cleanUpAppliedManifestWorks removes finalizer from the AppliedManifestWorks whose name starts with


### PR DESCRIPTION
when we delete the klusterlet, if the managed cluster was destroyed, we will skip cleaning up resources on the managed cluster.